### PR TITLE
Add object stats page

### DIFF
--- a/the_bazaar/forms/object_stats_filter.py
+++ b/the_bazaar/forms/object_stats_filter.py
@@ -1,0 +1,12 @@
+from django import forms
+
+from the_bazaar.constants.character import Character
+
+
+class ObjectStatsFilterForm(forms.Form):
+    character = forms.ChoiceField(
+        choices=[('', 'All Characters')] + Character.choices,
+        required=False,
+        label='Character',
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )

--- a/the_bazaar/services/aggregate_object_stats.py
+++ b/the_bazaar/services/aggregate_object_stats.py
@@ -1,0 +1,40 @@
+from the_bazaar.constants.character import Character
+from the_bazaar.models import Object
+from the_bazaar.value_objects.aggregate_object_stats import AggregateObjectStatsResult
+
+
+class AggregateObjectStatsService:
+    def __init__(self, character: str | None = None):
+        self.character = character
+        self.sanitize()
+        label = Character(character).label if character else "All"
+        self.result = AggregateObjectStatsResult(character=label)
+        self.objects = self.get_objects()
+        self.compute()
+
+    def sanitize(self):
+        if self.character is not None and self.character not in Character.values:
+            raise ValueError(f"{self.character} is not a valid character.")
+
+    def get_objects(self):
+        if self.character:
+            return Object.objects.filter(character=self.character)
+        return Object.objects.all()
+
+    def compute(self):
+        self.compute_total_objects()
+        self.compute_mastered_objects()
+        self.compute_mastered_ratio()
+
+    def compute_total_objects(self):
+        self.result.total_objects = self.objects.count()
+
+    def compute_mastered_objects(self):
+        self.result.mastered_objects = self.objects.filter(was_mastered=True).count()
+
+    def compute_mastered_ratio(self):
+        if self.result.total_objects == 0:
+            self.result.mastered_ratio = 0.0
+        else:
+            ratio = self.result.mastered_objects / self.result.total_objects * 100
+            self.result.mastered_ratio = round(ratio, 2)

--- a/the_bazaar/templates/the_bazaar/header.html
+++ b/the_bazaar/templates/the_bazaar/header.html
@@ -21,6 +21,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'the_bazaar:object_list' %}">🔧 Objects</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'the_bazaar:object_stats' %}">📊 Object stats</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/the_bazaar/templates/the_bazaar/object_stats.html
+++ b/the_bazaar/templates/the_bazaar/object_stats.html
@@ -1,0 +1,33 @@
+{% extends 'the_bazaar/base.html' %}
+{% load form_filters %}
+
+{% block content %}
+    <div class="container mt-4">
+        <h2>Object Statistics</h2>
+        <form method="get" class="row mb-3 g-2 align-items-end">
+            <div class="col-auto">
+                {{ form.character.label_tag }}
+                {{ form.character|add_class:"form-select" }}
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Filter</button>
+            </div>
+        </form>
+        <table class="table table-striped w-auto">
+            <tbody>
+            <tr>
+                <th scope="row">Total Objects</th>
+                <td>{{ stats.total_objects }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Mastered Objects</th>
+                <td>{{ stats.mastered_objects }}</td>
+            </tr>
+            <tr>
+                <th scope="row">Mastery Ratio</th>
+                <td>{{ stats.mastered_ratio }}%</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/the_bazaar/urls.py
+++ b/the_bazaar/urls.py
@@ -5,6 +5,7 @@ from the_bazaar.views.archetype_aggregate import BazaarAggregate as ArchetypeBaz
 from the_bazaar.views.monster_beater import MonsterBeaterView
 from the_bazaar.views.run_list import RunCreateView, RunUpdateView, RunDeleteView, RunListView
 from the_bazaar.views.object_list import ObjectListView, ObjectCreateView
+from the_bazaar.views.object_stats import ObjectStatsView
 
 app_name = 'the_bazaar'
 
@@ -19,4 +20,5 @@ urlpatterns = [
     path('monster_beater_home', MonsterBeaterView.home, name='monster_beater_home'),
     path('object/', ObjectListView.as_view(), name='object_list'),
     path('object/new/', ObjectCreateView.as_view(), name='object_create'),
+    path('object_stats/', ObjectStatsView.stats, name='object_stats'),
 ]

--- a/the_bazaar/value_objects/aggregate_object_stats.py
+++ b/the_bazaar/value_objects/aggregate_object_stats.py
@@ -1,0 +1,9 @@
+import dataclasses
+
+
+@dataclasses.dataclass
+class AggregateObjectStatsResult:
+    character: str
+    total_objects: int = 0
+    mastered_objects: int = 0
+    mastered_ratio: float = 0.0

--- a/the_bazaar/views/object_stats.py
+++ b/the_bazaar/views/object_stats.py
@@ -1,0 +1,22 @@
+from django.shortcuts import render
+
+from the_bazaar.forms.object_stats_filter import ObjectStatsFilterForm
+from the_bazaar.services.aggregate_object_stats import AggregateObjectStatsService
+
+
+class ObjectStatsView:
+    @staticmethod
+    def stats(request):
+        form = ObjectStatsFilterForm(request.GET)
+        character = None
+        if form.is_valid():
+            character = form.cleaned_data.get('character') or None
+        service = AggregateObjectStatsService(character)
+        return render(
+            request,
+            'the_bazaar/object_stats.html',
+            {
+                'stats': service.result,
+                'form': form,
+            }
+        )


### PR DESCRIPTION
## Summary
- add service and result value-object to compute object stats per character
- expose new `object_stats` view and template
- link to object stats in header and add URL

## Testing
- `make test` *(fails: EvaluationRepository.get_all_family_positive_vote missing required arg user)*

------
https://chatgpt.com/codex/tasks/task_e_683ffdb7bb20832991f6c26b81391ae1