### PR TITLE
Add update version action to Deck admin

### DIFF
--- a/altered/models/deck.py
+++ b/altered/models/deck.py
@@ -1,7 +1,8 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.db import models
 
 from altered.models import Champion
+from altered.services.altered_fetch_deck_data import AlteredFetchDeckDataService
 
 
 class Deck(models.Model):
@@ -28,3 +29,14 @@ class DeckAdmin(admin.ModelAdmin):
     list_display = ('name', 'champion',)
     list_filter = ('champion',)
     ordering = ('name',)
+    actions = ["update_version"]
+
+    @admin.action(description="Update version")
+    def update_version(self, request, queryset):
+        for deck in queryset:
+            AlteredFetchDeckDataService(deck).handle()
+        self.message_user(
+            request,
+            f"Updated {queryset.count()} deck(s)",
+            messages.SUCCESS,
+        )


### PR DESCRIPTION
## Summary
- add AlteredFetchDeckDataService import to Deck model admin
- add `update_version` admin action for Decks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68407bc8ad848329a277ac001fdb4d7d