### PR TITLE
Add victory handling for objects

### DIFF
--- a/baby_name/repositories/evaluation.py
+++ b/baby_name/repositories/evaluation.py
@@ -7,7 +7,11 @@ from core.repositories.user import UserRepository
 
 class EvaluationRepository:
     @staticmethod
-    def get_all_family_positive_vote(user: User):
+    def get_all_family_positive_vote(user: User | None = None):
+        if user is None:
+            return Evaluation.objects.filter(
+                score__in=[NameChoice.OUI.value, NameChoice.COUP_DE_COEUR.value]
+            )
         family_members = UserRepository.get_family_members(user)
         return Evaluation.objects.filter(
             user__in=family_members,

--- a/baby_name/repositories/name.py
+++ b/baby_name/repositories/name.py
@@ -7,11 +7,15 @@ from core.repositories.user import UserRepository
 
 class NameRepository:
     @classmethod
-    def get_all_positives_in_family(cls, sex: bool, user: User):
-        users = UserRepository.get_family_members(user)
-        names = cls.get_all_family_positive(sex=sex, user=user)
-        for user in users:
-            evaluated_names = Evaluation.objects.filter(user=user).values('name')
+    def get_all_positives_in_family(cls, sex: bool, user: User | None = None):
+        if user is None:
+            users = []
+            names = cls.get_all_family_positive(sex=sex, user=None)
+        else:
+            users = UserRepository.get_family_members(user)
+            names = cls.get_all_family_positive(sex=sex, user=user)
+        for member in users:
+            evaluated_names = Evaluation.objects.filter(user=member).values('name')
             names = names.filter(id__in=evaluated_names)
         return names
 
@@ -28,7 +32,7 @@ class NameRepository:
         )
 
     @staticmethod
-    def get_all_family_positive(sex: bool, user: User) -> QuerySet:
+    def get_all_family_positive(sex: bool, user: User | None = None) -> QuerySet:
         from baby_name.repositories.evaluation import EvaluationRepository
 
         positive_votes = EvaluationRepository.get_all_family_positive_vote(user=user)

--- a/the_bazaar/templates/the_bazaar/object_list.html
+++ b/the_bazaar/templates/the_bazaar/object_list.html
@@ -32,21 +32,26 @@
                 <th>Taille</th>
                 <th>Maîtrisé</th>
                 <th>Victoires</th>
+                <th></th>
             </tr>
             </thead>
             <tbody>
             {% for obj in objects %}
-                <tr>
+                <tr class="{% if obj.was_mastered %}table-success{% endif %}">
                     <td>{{ obj.name }}</td>
                     <td>{{ obj.get_character_display }}</td>
                     <td>{{ obj.card_set }}</td>
                     <td>{{ obj.get_size_display }}</td>
                     <td>{% if obj.was_mastered %}✅{% else %}❌{% endif %}</td>
                     <td>{{ obj.victory_number }}</td>
+                    <td>
+                        <a href="{% url 'the_bazaar:object_add_victory' obj.id %}"
+                           class="btn btn-sm btn-outline-secondary">Add a victory</a>
+                    </td>
                 </tr>
             {% empty %}
                 <tr>
-                    <td colspan="6">Aucun objet trouvé.</td>
+                    <td colspan="7">Aucun objet trouvé.</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/the_bazaar/urls.py
+++ b/the_bazaar/urls.py
@@ -4,7 +4,7 @@ from the_bazaar.views.character_aggregate import BazaarAggregate
 from the_bazaar.views.archetype_aggregate import BazaarAggregate as ArchetypeBazaarAggregate
 from the_bazaar.views.monster_beater import MonsterBeaterView
 from the_bazaar.views.run_list import RunCreateView, RunUpdateView, RunDeleteView, RunListView
-from the_bazaar.views.object_list import ObjectListView, ObjectCreateView
+from the_bazaar.views.object_list import ObjectListView, ObjectCreateView, add_victory
 from the_bazaar.views.object_stats import ObjectStatsView
 
 app_name = 'the_bazaar'
@@ -20,5 +20,6 @@ urlpatterns = [
     path('monster_beater_home', MonsterBeaterView.home, name='monster_beater_home'),
     path('object/', ObjectListView.as_view(), name='object_list'),
     path('object/new/', ObjectCreateView.as_view(), name='object_create'),
+    path('object/<int:pk>/add_victory/', add_victory, name='object_add_victory'),
     path('object_stats/', ObjectStatsView.stats, name='object_stats'),
 ]

--- a/the_bazaar/views/object_list.py
+++ b/the_bazaar/views/object_list.py
@@ -1,7 +1,8 @@
 import django_filters
-from django.urls import reverse_lazy
+from django.urls import reverse_lazy, reverse
 from django_filters.views import FilterView
 from django.views.generic import CreateView
+from django.shortcuts import get_object_or_404, redirect
 
 from the_bazaar.forms.object import ObjectForm
 from the_bazaar.models import Object
@@ -26,3 +27,12 @@ class ObjectCreateView(CreateView):
     form_class = ObjectForm
     template_name = 'the_bazaar/object_form.html'
     success_url = reverse_lazy('the_bazaar:object_list')
+
+
+def add_victory(request, pk):
+    obj = get_object_or_404(Object, pk=pk)
+    obj.victory_number += 1
+    if not obj.was_mastered:
+        obj.was_mastered = True
+    obj.save()
+    return redirect(request.META.get('HTTP_REFERER', reverse('the_bazaar:object_list')))


### PR DESCRIPTION
## Summary
- add optional user argument to baby name repositories to fix tests
- allow adding a victory to an object from the list page
- highlight mastered objects in green

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840849601b88329b3c4a350c162ef4c