### PR TITLE
Add deck statistics view

### DIFF
--- a/altered/forms/deck_filter.py
+++ b/altered/forms/deck_filter.py
@@ -1,0 +1,12 @@
+from django import forms
+
+from altered.constants.faction import Faction
+
+
+class DeckFilterForm(forms.Form):
+    faction = forms.ChoiceField(
+        choices=[('', 'All Factions')] + Faction.choices,
+        required=False,
+        label='Faction',
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )

--- a/altered/services/__init__.py
+++ b/altered/services/__init__.py
@@ -1,0 +1,2 @@
+from .altered_fetch_deck_data import AlteredFetchDeckDataService
+from .deck_game_stats import DeckGameStatsService

--- a/altered/services/deck_game_stats.py
+++ b/altered/services/deck_game_stats.py
@@ -1,0 +1,19 @@
+from altered.models import Deck, Game
+from altered.value_objects.deck_game_stats import DeckGameStats
+
+
+class DeckGameStatsService:
+    def __init__(self, deck: Deck):
+        self.deck = deck
+        self.result = DeckGameStats(deck=deck)
+        self.games = Game.objects.filter(deck=deck)
+        self.compute()
+
+    def compute(self):
+        self.result.match_number = self.games.count()
+        self.result.win_number = self.games.filter(is_win=True).count()
+        if self.result.match_number:
+            ratio = self.result.win_number / self.result.match_number * 100
+            self.result.win_ratio = round(ratio, 2)
+        else:
+            self.result.win_ratio = 0.0

--- a/altered/templates/altered/deck_stats.html
+++ b/altered/templates/altered/deck_stats.html
@@ -1,0 +1,46 @@
+{% extends 'altered/base.html' %}
+{% load form_filters %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Deck Statistics</h2>
+    <form method="get" class="row mb-3 g-2 align-items-end">
+        <div class="col-auto">
+            {{ form.faction.label_tag }}
+            {{ form.faction|add_class:"form-select" }}
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+    </form>
+
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Deck</th>
+            <th>Champion</th>
+            <th>Faction</th>
+            <th>Matches</th>
+            <th>Wins</th>
+            <th>Win %</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for stat in stats %}
+            <tr>
+                <td>{{ stat.deck.name }}</td>
+                <td>{{ stat.deck.champion.name }}</td>
+                <td>{{ stat.deck.champion.faction }}</td>
+                <td>{{ stat.match_number }}</td>
+                <td>{{ stat.win_number }}</td>
+                <td>{{ stat.win_ratio }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="6" class="text-center">No deck data available.</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/altered/templates/altered/header.html
+++ b/altered/templates/altered/header.html
@@ -9,6 +9,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'altered:game_form' %}">Add Game</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'altered:deck_stats' %}">Deck Stats</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/altered/urls.py
+++ b/altered/urls.py
@@ -2,10 +2,12 @@ from django.urls import path
 
 from altered.views.home import home
 from altered.views import game_form_view
+from altered.views.deck_stats import deck_stats_view
 
 app_name = "altered"
 
 urlpatterns = [
     path("", home, name="home"),
     path('game/', game_form_view, name='game_form'),
+    path('decks/', deck_stats_view, name='deck_stats'),
 ]

--- a/altered/value_objects/__init__.py
+++ b/altered/value_objects/__init__.py
@@ -1,0 +1,1 @@
+from .deck_game_stats import DeckGameStats

--- a/altered/value_objects/deck_game_stats.py
+++ b/altered/value_objects/deck_game_stats.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from altered.models import Deck
+
+
+@dataclass
+class DeckGameStats:
+    deck: Deck
+    match_number: int = 0
+    win_number: int = 0
+    win_ratio: float = 0.0

--- a/altered/views/__init__.py
+++ b/altered/views/__init__.py
@@ -1,1 +1,2 @@
 from .game import game_form_view
+from .deck_stats import deck_stats_view

--- a/altered/views/deck_stats.py
+++ b/altered/views/deck_stats.py
@@ -1,0 +1,21 @@
+from django.shortcuts import render
+
+from altered.forms.deck_filter import DeckFilterForm
+from altered.models import Deck
+from altered.services.deck_game_stats import DeckGameStatsService
+
+
+def deck_stats_view(request):
+    form = DeckFilterForm(request.GET)
+    faction = None
+    if form.is_valid():
+        faction = form.cleaned_data.get('faction') or None
+
+    decks = Deck.objects.select_related('champion')
+    if faction:
+        decks = decks.filter(champion__faction=faction)
+
+    stats = [DeckGameStatsService(deck).result for deck in decks]
+    stats.sort(key=lambda x: x.match_number, reverse=True)
+
+    return render(request, 'altered/deck_stats.html', {'stats': stats, 'form': form})


### PR DESCRIPTION
## Summary
- show deck stats (matches, wins, win ratio)
- add filter form by faction
- display deck stats in a new page
- link deck stats in header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68414b1f3b908329bda2fc0a996c3b3c