### PR TITLE
Add Meta Stats page in Altered

### DIFF
--- a/altered/constants/__init__.py
+++ b/altered/constants/__init__.py
@@ -1,0 +1,1 @@
+from .duration import Duration

--- a/altered/constants/duration.py
+++ b/altered/constants/duration.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class Duration(models.TextChoices):
+    ALL = "ALL", "All time"
+    LAST_6_MONTHS = "6_MONTHS", "Last 6 months"
+    LAST_3_MONTHS = "3_MONTHS", "Last 3 months"
+    LAST_MONTH = "1_MONTH", "Last month"

--- a/altered/forms/meta_stats_filter.py
+++ b/altered/forms/meta_stats_filter.py
@@ -1,0 +1,12 @@
+from django import forms
+
+from altered.constants.duration import Duration
+
+
+class MetaStatsFilterForm(forms.Form):
+    duration = forms.ChoiceField(
+        choices=Duration.choices,
+        required=False,
+        label='Duration',
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )

--- a/altered/services/__init__.py
+++ b/altered/services/__init__.py
@@ -1,2 +1,3 @@
 from .altered_fetch_deck_data import AlteredFetchDeckDataService
 from .deck_game_stats import DeckGameStatsService
+from .meta_game_stats import MetaGameStatsService

--- a/altered/services/meta_game_stats.py
+++ b/altered/services/meta_game_stats.py
@@ -1,0 +1,49 @@
+from datetime import timedelta
+from django.db.models import Count, Q
+from django.utils import timezone
+
+from altered.constants.duration import Duration
+from altered.models import Champion, Game
+from altered.value_objects.champion_game_stats import ChampionGameStats
+
+
+class MetaGameStatsService:
+    def __init__(self, duration: str = Duration.ALL):
+        self.duration = duration or Duration.ALL
+        self.games = self.get_games()
+        self.result: list[ChampionGameStats] = []
+        self.compute()
+
+    def get_games(self):
+        qs = Game.objects.all()
+        if self.duration == Duration.LAST_MONTH:
+            qs = qs.filter(created_at__gte=timezone.now() - timedelta(days=30))
+        elif self.duration == Duration.LAST_3_MONTHS:
+            qs = qs.filter(created_at__gte=timezone.now() - timedelta(days=90))
+        elif self.duration == Duration.LAST_6_MONTHS:
+            qs = qs.filter(created_at__gte=timezone.now() - timedelta(days=180))
+        return qs
+
+    def compute(self):
+        data = (
+            self.games.values('opponent_champion')
+            .annotate(
+                match_number=Count('id'),
+                win_number=Count('id', filter=Q(is_win=True))
+            )
+            .order_by('-match_number')
+        )
+        for entry in data:
+            champion = Champion.objects.get(pk=entry['opponent_champion'])
+            match_number = entry['match_number']
+            win_number = entry['win_number']
+            win_ratio = round(win_number / match_number * 100, 2) if match_number else 0.0
+            self.result.append(
+                ChampionGameStats(
+                    champion=champion,
+                    match_number=match_number,
+                    win_number=win_number,
+                    win_ratio=win_ratio,
+                )
+            )
+

--- a/altered/templates/altered/header.html
+++ b/altered/templates/altered/header.html
@@ -12,6 +12,9 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'altered:deck_stats' %}">Deck Stats</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'altered:meta_stats' %}">Meta Stats</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/altered/templates/altered/meta_stats.html
+++ b/altered/templates/altered/meta_stats.html
@@ -1,0 +1,44 @@
+{% extends 'altered/base.html' %}
+{% load form_filters %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Meta Statistics</h2>
+    <form method="get" class="row mb-3 g-2 align-items-end">
+        <div class="col-auto">
+            {{ form.duration.label_tag }}
+            {{ form.duration|add_class:"form-select" }}
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+    </form>
+
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Champion</th>
+            <th>Faction</th>
+            <th>Matches</th>
+            <th>Wins</th>
+            <th>Win %</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for stat in stats %}
+            <tr>
+                <td>{{ stat.champion.name }}</td>
+                <td>{{ stat.champion.faction }}</td>
+                <td>{{ stat.match_number }}</td>
+                <td>{{ stat.win_number }}</td>
+                <td>{{ stat.win_ratio }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="5" class="text-center">No meta data available.</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/altered/urls.py
+++ b/altered/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from altered.views.home import home
 from altered.views import game_form_view
 from altered.views.deck_stats import deck_stats_view
+from altered.views.meta_stats import meta_stats_view
 
 app_name = "altered"
 
@@ -10,4 +11,5 @@ urlpatterns = [
     path("", home, name="home"),
     path('game/', game_form_view, name='game_form'),
     path('decks/', deck_stats_view, name='deck_stats'),
+    path('meta/', meta_stats_view, name='meta_stats'),
 ]

--- a/altered/value_objects/__init__.py
+++ b/altered/value_objects/__init__.py
@@ -1,1 +1,2 @@
 from .deck_game_stats import DeckGameStats
+from .champion_game_stats import ChampionGameStats

--- a/altered/value_objects/champion_game_stats.py
+++ b/altered/value_objects/champion_game_stats.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from altered.models import Champion
+
+
+@dataclass
+class ChampionGameStats:
+    champion: Champion
+    match_number: int = 0
+    win_number: int = 0
+    win_ratio: float = 0.0

--- a/altered/views/__init__.py
+++ b/altered/views/__init__.py
@@ -1,2 +1,4 @@
 from .game import game_form_view
 from .deck_stats import deck_stats_view
+from .meta_stats import meta_stats_view
+

--- a/altered/views/meta_stats.py
+++ b/altered/views/meta_stats.py
@@ -1,0 +1,15 @@
+from django.shortcuts import render
+
+from altered.forms.meta_stats_filter import MetaStatsFilterForm
+from altered.services.meta_game_stats import MetaGameStatsService
+from altered.constants.duration import Duration
+
+
+def meta_stats_view(request):
+    form = MetaStatsFilterForm(request.GET)
+    duration = Duration.ALL
+    if form.is_valid():
+        duration = form.cleaned_data.get('duration') or Duration.ALL
+    service = MetaGameStatsService(duration)
+    return render(request, 'altered/meta_stats.html', {'stats': service.result, 'form': form})
+


### PR DESCRIPTION
## Summary
- implement champion-based meta stats aggregated by time range
- add duration constants and filtering form
- link new stats in navigation
- expose service and value objects for champion stats

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684858e4e37c8329a6ab171fe642bead