### PR TITLE
Add edit button and score filter for course history

### DIFF
--- a/shopping_list/forms/course_history.py
+++ b/shopping_list/forms/course_history.py
@@ -1,0 +1,17 @@
+from django import forms
+
+from shopping_list.models import CourseHistory
+
+
+class CourseHistoryForm(forms.ModelForm):
+    class Meta:
+        model = CourseHistory
+        fields = ["rating", "notes"]
+        widgets = {
+            "rating": forms.NumberInput(attrs={"class": "form-control", "min": 0, "max": 10}),
+            "notes": forms.Textarea(attrs={"class": "form-control", "rows": 3}),
+        }
+        labels = {
+            "rating": "Score",
+            "notes": "Commentaire",
+        }

--- a/shopping_list/templates/shopping_list/edit_course_history.html
+++ b/shopping_list/templates/shopping_list/edit_course_history.html
@@ -1,0 +1,23 @@
+{% extends 'shopping_list/base.html' %}
+
+{% block title %}Editer Historique{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h2>Éditer "{{ history.course.name }}"</h2>
+
+    <form method="post" class="card p-4 shadow-sm">
+        {% csrf_token %}
+        <div class="mb-3">
+            {{ form.rating.label_tag }}
+            {{ form.rating }}
+        </div>
+        <div class="mb-3">
+            {{ form.notes.label_tag }}
+            {{ form.notes }}
+        </div>
+        <button type="submit" class="btn btn-primary">Sauvegarder</button>
+        <a href="{% url 'shopping_list:course_history' %}" class="btn btn-secondary">Annuler</a>
+    </form>
+</div>
+{% endblock %}

--- a/shopping_list/templates/shopping_list/index_course_history.html
+++ b/shopping_list/templates/shopping_list/index_course_history.html
@@ -5,20 +5,35 @@
 {% block content %}
     <div class="container py-4">
         <h2>List des derniers repas</h2>
+        <form method="get" class="row g-3 mb-3">
+            <div class="col-auto">
+                <input type="number" name="min_score" min="0" max="10" class="form-control" placeholder="Score min" value="{{ min_score }}">
+            </div>
+            <div class="col-auto">
+                <input type="number" name="max_score" min="0" max="10" class="form-control" placeholder="Score max" value="{{ max_score }}">
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">Filtrer</button>
+            </div>
+        </form>
         <table class="table table-striped">
             <thead>
             <tr>
                 <th>Nom</th>
                 <th>Score (sur 10)</th>
                 <th>Commentaire</th>
+                <th>Action</th>
             </tr>
             </thead>
             <tbody>
-            {% for course in courses %}
+            {% for history in courses %}
                 <tr>
-                    <td>{{ course.course.name }}</td>
-                    <td>{{ course.rating }}</td>
-                    <td>{{ course.notes }}</td>
+                    <td>{{ history.course.name }}</td>
+                    <td>{{ history.rating }}</td>
+                    <td>{{ history.notes }}</td>
+                    <td>
+                        <a class="text-decoration-none text-reset" href="{% url 'shopping_list:course_history_edit' history.id %}">✏️</a>
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/shopping_list/urls.py
+++ b/shopping_list/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
     path("configuration", configuration, name="configuration"),
     path("course", CourseController.index, name="course"),
     path("course/history", CourseHistoryController.index, name="course_history"),
+    path(
+        "course/history/<int:history_id>/edit",
+        CourseHistoryController.edit,
+        name="course_history_edit",
+    ),
     path("course/new", CourseController.add_course, name="add_course"),
     path("course/<int:course_id>/edit", CourseController.edit_course, name="edit_course"),
     path("ingredient/new", add_ingredient, name="add_ingredient"),

--- a/shopping_list/views/course_history.py
+++ b/shopping_list/views/course_history.py
@@ -1,4 +1,6 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404, redirect
+
+from shopping_list.forms.course_history import CourseHistoryForm
 
 from shopping_list.models import CourseHistory
 
@@ -6,6 +8,45 @@ from shopping_list.models import CourseHistory
 class CourseHistoryController:
     @staticmethod
     def index(request):
-        courses = CourseHistory.objects.all().order_by('-created_at')[:10]
+        courses = CourseHistory.objects.all()
 
-        return render(request, 'shopping_list/index_course_history.html', {'courses': courses})
+        min_score = request.GET.get('min_score')
+        if min_score and min_score.isdigit():
+            courses = courses.filter(rating__gte=int(min_score))
+
+        max_score = request.GET.get('max_score')
+        if max_score and max_score.isdigit():
+            courses = courses.filter(rating__lte=int(max_score))
+
+        courses = courses.order_by('-created_at')[:10]
+
+        return render(
+            request,
+            'shopping_list/index_course_history.html',
+            {
+                'courses': courses,
+                'min_score': min_score,
+                'max_score': max_score,
+            }
+        )
+
+    @staticmethod
+    def edit(request, history_id):
+        history = get_object_or_404(CourseHistory, id=history_id)
+
+        if request.method == 'POST':
+            form = CourseHistoryForm(request.POST, instance=history)
+            if form.is_valid():
+                form.save()
+                return redirect('shopping_list:course_history')
+        else:
+            form = CourseHistoryForm(instance=history)
+
+        return render(
+            request,
+            'shopping_list/edit_course_history.html',
+            {
+                'form': form,
+                'history': history,
+            }
+        )


### PR DESCRIPTION
## Summary
- add a `CourseHistoryForm` for rating and comment editing
- allow filtering by score range on course history page
- provide page to edit a history entry
- expose new edit route
- show edit links and score filter form in course history template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f09d862ac8329b46ae9ed53bd208e