### PR TITLE
Add ingredient history page

### DIFF
--- a/shopping_list/templates/shopping_list/header.html
+++ b/shopping_list/templates/shopping_list/header.html
@@ -11,6 +11,9 @@
             <li class="nav-item">
                 <a class="nav-link" href="{% url 'shopping_list:course_history' %}">Historique</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'shopping_list:ingredient_history' %}">Achats</a>
+            </li>
         </ul>
     </div>
 </nav>

--- a/shopping_list/templates/shopping_list/index_ingredient_history.html
+++ b/shopping_list/templates/shopping_list/index_ingredient_history.html
@@ -1,0 +1,39 @@
+{% extends 'shopping_list/base.html' %}
+
+{% block title %}Achats{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h2>Articles achetés</h2>
+    <form method="get" class="row g-3 mb-3">
+        <div class="col-auto">
+            <select name="period" class="form-select">
+                <option value="all" {% if period == 'all' %}selected{% endif %}>Tout le temps</option>
+                <option value="6m" {% if period == '6m' %}selected{% endif %}>6 derniers mois</option>
+                <option value="1m" {% if period == '1m' %}selected{% endif %}>Dernier mois</option>
+            </select>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filtrer</button>
+        </div>
+    </form>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Ingrédient</th>
+            <th>Catégorie</th>
+            <th>Quantité achetée</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for item in items %}
+        <tr>
+            <td>{{ item.ingredient__name }}</td>
+            <td>{{ item.ingredient__category }}</td>
+            <td>{{ item.total_quantity }} ({{ item.ingredient__unit }})</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/shopping_list/tests/test_ingredient_history_view.py
+++ b/shopping_list/tests/test_ingredient_history_view.py
@@ -1,0 +1,61 @@
+import datetime
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.utils import timezone
+
+from django.contrib.auth.models import User
+
+from shopping_list.constants.category import Category
+from shopping_list.models import Ingredient
+from shopping_list.models.ingredient_history import IngredientHistory
+
+
+class IngredientHistoryViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.client = Client()
+        self.client.login(username="tester", password="pass")
+
+        self.apple = Ingredient.objects.create(
+            name="Apple", is_pantry_staples=False, unit="pc", category=Category.FRUIT
+        )
+        self.milk = Ingredient.objects.create(
+            name="Milk", is_pantry_staples=False, unit="l", category=Category.DAIRY
+        )
+
+        now = timezone.now()
+        IngredientHistory.objects.create(
+            ingredient=self.apple,
+            quantity=2,
+            bought_date=now - datetime.timedelta(days=10),
+        )
+        IngredientHistory.objects.create(
+            ingredient=self.apple,
+            quantity=3,
+            bought_date=now - datetime.timedelta(days=40),
+        )
+        IngredientHistory.objects.create(
+            ingredient=self.milk,
+            quantity=1,
+            bought_date=now - datetime.timedelta(days=200),
+        )
+
+        self.url = reverse("shopping_list:ingredient_history")
+
+    def test_all_time_aggregation(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        items = response.context["items"]
+        totals = {i["ingredient__name"]: i["total_quantity"] for i in items}
+        self.assertEqual(totals["Apple"], 5)
+        self.assertEqual(totals["Milk"], 1)
+
+    def test_last_month_filter(self):
+        response = self.client.get(self.url, {"period": "1m"})
+        self.assertEqual(response.status_code, 200)
+        items = response.context["items"]
+        names = [i["ingredient__name"] for i in items]
+        self.assertIn("Apple", names)
+        self.assertNotIn("Milk", names)
+        totals = {i["ingredient__name"]: i["total_quantity"] for i in items}
+        self.assertEqual(totals["Apple"], 2)

--- a/shopping_list/urls.py
+++ b/shopping_list/urls.py
@@ -8,6 +8,7 @@ from shopping_list.views.ingredient import add_ingredient
 from shopping_list.views.meal import meal
 from shopping_list.views.planned_course import PlannedCourseController
 from shopping_list.views.planned_ingredients import PlannedIngredientController
+from shopping_list.views.ingredient_history import IngredientHistoryController
 
 app_name = "shopping_list"
 
@@ -23,14 +24,45 @@ urlpatterns = [
         name="course_history_edit",
     ),
     path("course/new", CourseController.add_course, name="add_course"),
-    path("course/<int:course_id>/edit", CourseController.edit_course, name="edit_course"),
+    path(
+        "course/<int:course_id>/edit", CourseController.edit_course, name="edit_course"
+    ),
     path("ingredient/new", add_ingredient, name="add_ingredient"),
     path("meal/", meal, name="meal"),
     path("planned_course/", PlannedCourseController.index, name="planned_course"),
-    path("planned_course/add", PlannedCourseController.add_api, name="planned_course_add_api"),
-    path("planned_course/delete", PlannedCourseController.delete, name="planned_course_delete"),
-    path("planned_course/new", PlannedCourseController.add_page, name="planned_course_add_page"),
-    path("shopping_list/add", PlannedIngredientController.add_api, name="shopping_list_add_api"),
-    path("shopping_list/delete", PlannedIngredientController.delete, name="shopping_list_delete"),
-    path("shopping_list/new", PlannedIngredientController.add_page, name="shopping_list_add_page"),
+    path(
+        "planned_course/add",
+        PlannedCourseController.add_api,
+        name="planned_course_add_api",
+    ),
+    path(
+        "planned_course/delete",
+        PlannedCourseController.delete,
+        name="planned_course_delete",
+    ),
+    path(
+        "planned_course/new",
+        PlannedCourseController.add_page,
+        name="planned_course_add_page",
+    ),
+    path(
+        "shopping_list/add",
+        PlannedIngredientController.add_api,
+        name="shopping_list_add_api",
+    ),
+    path(
+        "shopping_list/delete",
+        PlannedIngredientController.delete,
+        name="shopping_list_delete",
+    ),
+    path(
+        "shopping_list/new",
+        PlannedIngredientController.add_page,
+        name="shopping_list_add_page",
+    ),
+    path(
+        "ingredient/history",
+        IngredientHistoryController.index,
+        name="ingredient_history",
+    ),
 ]

--- a/shopping_list/views/ingredient_history.py
+++ b/shopping_list/views/ingredient_history.py
@@ -1,0 +1,36 @@
+from django.db.models import Sum
+from django.shortcuts import render
+from django.utils import timezone
+
+from shopping_list.models.ingredient_history import IngredientHistory
+
+
+class IngredientHistoryController:
+    @staticmethod
+    def index(request):
+        histories = IngredientHistory.objects.select_related("ingredient")
+
+        period = request.GET.get("period", "all")
+        if period == "6m":
+            since = timezone.now() - timezone.timedelta(days=180)
+            histories = histories.filter(bought_date__gte=since)
+        elif period == "1m":
+            since = timezone.now() - timezone.timedelta(days=30)
+            histories = histories.filter(bought_date__gte=since)
+
+        items = (
+            histories.values(
+                "ingredient__name", "ingredient__unit", "ingredient__category"
+            )
+            .annotate(total_quantity=Sum("quantity"))
+            .order_by("ingredient__name")
+        )
+
+        return render(
+            request,
+            "shopping_list/index_ingredient_history.html",
+            {
+                "items": items,
+                "period": period,
+            },
+        )


### PR DESCRIPTION
## Summary
- add `IngredientHistoryController` view to display purchased items
- add template `index_ingredient_history.html`
- link the new page in header and urls
- test the new page aggregation and filtering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f15d18488832998396044e2764d11