### PR TITLE
Restrict modules to admins

### DIFF
--- a/bricolle_family/middleware/admin_required_middleware.py
+++ b/bricolle_family/middleware/admin_required_middleware.py
@@ -1,0 +1,33 @@
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+EXEMPT_PREFIXES = [
+    "/baby_name/",
+    settings.STATIC_URL,
+    settings.MEDIA_URL,
+]
+
+EXEMPT_URLS = [
+    reverse("login"),
+    reverse("logout"),
+    reverse("home"),
+    reverse("games"),
+    reverse("more"),
+]
+
+
+class AdminRequiredMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.user.is_authenticated and not request.user.is_staff:
+            path = request.path_info
+            if (
+                not any(path.startswith(p) for p in EXEMPT_PREFIXES)
+                and path not in EXEMPT_URLS
+            ):
+                return redirect("home")
+        return self.get_response(request)

--- a/bricolle_family/settings.py
+++ b/bricolle_family/settings.py
@@ -9,123 +9,120 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Ensure a default SECRET_KEY is set for environments where it might not be (e.g., testing)
 # Try to load from environment, but if not found or is None, use a dummy key.
-SECRET_KEY = config('SECRET_KEY', default=None)
+SECRET_KEY = config("SECRET_KEY", default=None)
 if not SECRET_KEY:
-    SECRET_KEY = 'dummy_secret_key_for_testing_do_not_use_in_production'
+    SECRET_KEY = "dummy_secret_key_for_testing_do_not_use_in_production"
 
 
-DEBUG = config('DEBUG', default=True)
-ENV = config('ENV', default='local')
+DEBUG = config("DEBUG", default=True)
+ENV = config("ENV", default="local")
 
-ALLOWED_HOSTS = [
-    "127.0.0.1",
-    "localhost",
-    "51.178.41.140",
-    "bricolle-family.fr"
-]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "51.178.41.140", "bricolle-family.fr"]
 
 INSTALLED_APPS = [
-    'bootstrap5',
-    'core.apps.CoreConfig',
-    'the_bazaar',
-    'baby_name',
-    'babyberon',
-    'northguard',
-    'chess',
-    'altered',
-    'battery_simulator',
-    'shopping_list.apps.ShoppingListConfig',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'widget_tweaks',
+    "bootstrap5",
+    "core.apps.CoreConfig",
+    "the_bazaar",
+    "baby_name",
+    "babyberon",
+    "northguard",
+    "chess",
+    "altered",
+    "battery_simulator",
+    "shopping_list.apps.ShoppingListConfig",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "widget_tweaks",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'bricolle_family.middleware.login_required_middleware.LoginRequiredMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "bricolle_family.middleware.login_required_middleware.LoginRequiredMiddleware",
+    "bricolle_family.middleware.admin_required_middleware.AdminRequiredMiddleware",
 ]
 
-ROOT_URLCONF = 'bricolle_family.urls'
+ROOT_URLCONF = "bricolle_family.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [
             os.path.join(BASE_DIR, "bricolle_family", "templates"),
         ],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'bricolle_family.wsgi.application'
+WSGI_APPLICATION = "bricolle_family.wsgi.application"
 
-if ENV == 'production':
+if ENV == "production":
     DATABASES = {
-        'default': dj_database_url.config(
-            default=config('DATABASE_URL'),
-            conn_max_age=600
+        "default": dj_database_url.config(
+            default=config("DATABASE_URL"), conn_max_age=600
         )
     }
 else:
     DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': BASE_DIR / 'db.sqlite3',
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
         }
     }
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'Europe/Paris'
+TIME_ZONE = "Europe/Paris"
 
 USE_I18N = True
 
 USE_TZ = False
 
-STATIC_URL = '/static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
-STATIC_ROOT = BASE_DIR / 'staticfiles'
+STATIC_URL = "/static/"
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+STATIC_ROOT = BASE_DIR / "staticfiles"
 
-STORAGES["staticfiles"] = {"BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage'}
+STORAGES["staticfiles"] = {
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+}
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-LOGIN_URL = 'login'
+LOGIN_URL = "login"
 
-MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"

--- a/bricolle_family/templates/bricolle_family/base.html
+++ b/bricolle_family/templates/bricolle_family/base.html
@@ -11,7 +11,7 @@
 </head>
 
 <body class="bg-light">
+{% include 'bricolle_family/header.html' %}
 {% block content %}
 {% endblock %}
-</body>
-</html>
+</body></html>

--- a/bricolle_family/templates/bricolle_family/header.html
+++ b/bricolle_family/templates/bricolle_family/header.html
@@ -1,0 +1,12 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light px-3">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{% url 'home' %}">Bricolle Family</a>
+        <div class="ms-auto">
+            {% if user.is_authenticated %}
+                <a class="btn btn-outline-secondary" href="{% url 'logout' %}">Logout</a>
+            {% else %}
+                <a class="btn btn-primary" href="{% url 'login' %}">Login</a>
+            {% endif %}
+        </div>
+    </div>
+</nav>

--- a/bricolle_family/views/login.py
+++ b/bricolle_family/views/login.py
@@ -18,4 +18,4 @@ class Login:
     @staticmethod
     def user_logout(request):
         logout(request)
-        return redirect("bricolle_family:login")
+        return redirect("login")

--- a/shopping_list/tests/test_ingredient_history.py
+++ b/shopping_list/tests/test_ingredient_history.py
@@ -4,31 +4,33 @@ from django.urls import reverse
 from django.utils import timezone
 
 from shopping_list.models import Ingredient, ShoppingListItem
-from shopping_list.models.ingredient_history import IngredientHistory # Ensure correct import
-from django.contrib.auth.models import User # Correct import for the User model
+from shopping_list.models.ingredient_history import (
+    IngredientHistory,
+)  # Ensure correct import
+from django.contrib.auth.models import User  # Correct import for the User model
+
 
 class IngredientHistoryCreationTests(TestCase):
 
     def setUp(self):
         # Create a user if view requires authentication
-        self.user = User.objects.create_user(username='testuser', password='password123')
+        self.user = User.objects.create_user(
+            username="testuser", password="password123", is_staff=True
+        )
         self.client = Client()
-        self.client.login(username='testuser', password='password123')
+        self.client.login(username="testuser", password="password123")
 
         # Create an Ingredient
         self.ingredient = Ingredient.objects.create(
-            name="Test Apple",
-            is_pantry_staples=False,
-            unit="piece"
+            name="Test Apple", is_pantry_staples=False, unit="piece"
         )
 
         # Create a ShoppingListItem
         self.shopping_list_item = ShoppingListItem.objects.create(
-            ingredient=self.ingredient,
-            quantity=2.00
+            ingredient=self.ingredient, quantity=2.00
         )
 
-        self.delete_url = reverse('shopping_list:shopping_list_delete')
+        self.delete_url = reverse("shopping_list:shopping_list_delete")
 
     def test_ingredient_history_created_on_shopping_list_item_delete(self):
         """
@@ -42,14 +44,16 @@ class IngredientHistoryCreationTests(TestCase):
         # The view expects a JSON body with 'planned_ingredient_id'
         response = self.client.post(
             self.delete_url,
-            data=json.dumps({'planned_ingredient_id': self.shopping_list_item.id}),
-            content_type='application/json'
+            data=json.dumps({"planned_ingredient_id": self.shopping_list_item.id}),
+            content_type="application/json",
         )
 
         self.assertEqual(response.status_code, 200)
         response_data = response.json()
-        self.assertEqual(response_data['status'], 'success')
-        self.assertEqual(response_data['message'], 'Item marked as bought and removed from list.')
+        self.assertEqual(response_data["status"], "success")
+        self.assertEqual(
+            response_data["message"], "Item marked as bought and removed from list."
+        )
 
         # Check that ShoppingListItem is deleted
         self.assertEqual(ShoppingListItem.objects.count(), 0)
@@ -59,45 +63,53 @@ class IngredientHistoryCreationTests(TestCase):
         history_entry = IngredientHistory.objects.first()
         self.assertIsNotNone(history_entry)
         self.assertEqual(history_entry.ingredient, self.ingredient)
-        self.assertEqual(float(history_entry.quantity), float(self.shopping_list_item.quantity)) # Compare as float due to DecimalField
+        self.assertEqual(
+            float(history_entry.quantity), float(self.shopping_list_item.quantity)
+        )  # Compare as float due to DecimalField
 
         # Check bought_date is recent (within a reasonable delta, e.g., 5 seconds)
-        self.assertTrue((timezone.now() - history_entry.bought_date).total_seconds() < 5)
+        self.assertTrue(
+            (timezone.now() - history_entry.bought_date).total_seconds() < 5
+        )
 
     def test_delete_missing_id(self):
         """Test delete request with missing planned_ingredient_id."""
         response = self.client.post(
             self.delete_url,
-            data=json.dumps({}), # Empty data
-            content_type='application/json'
+            data=json.dumps({}),  # Empty data
+            content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
         response_data = response.json()
-        self.assertEqual(response_data['status'], 'error')
-        self.assertEqual(response_data['message'], 'Missing planned_ingredient_id.')
-        self.assertEqual(ShoppingListItem.objects.count(), 1) # Item should not be deleted
-        self.assertEqual(IngredientHistory.objects.count(), 0) # No history created
+        self.assertEqual(response_data["status"], "error")
+        self.assertEqual(response_data["message"], "Missing planned_ingredient_id.")
+        self.assertEqual(
+            ShoppingListItem.objects.count(), 1
+        )  # Item should not be deleted
+        self.assertEqual(IngredientHistory.objects.count(), 0)  # No history created
 
     def test_delete_invalid_id(self):
         """Test delete request with an invalid (non-existent) planned_ingredient_id."""
         response = self.client.post(
             self.delete_url,
-            data=json.dumps({'planned_ingredient_id': 9999}), # Non-existent ID
-            content_type='application/json'
+            data=json.dumps({"planned_ingredient_id": 9999}),  # Non-existent ID
+            content_type="application/json",
         )
         # Django's get_object_or_404 raises Http404, which results in a 404 status code
-        self.assertEqual(response.status_code, 404) 
-        self.assertEqual(ShoppingListItem.objects.count(), 1) # Item should not be deleted
-        self.assertEqual(IngredientHistory.objects.count(), 0) # No history created
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            ShoppingListItem.objects.count(), 1
+        )  # Item should not be deleted
+        self.assertEqual(IngredientHistory.objects.count(), 0)  # No history created
 
     def test_delete_invalid_json(self):
         """Test delete request with invalid JSON."""
         response = self.client.post(
-            self.delete_url,
-            data="this is not json",
-            content_type='application/json'
+            self.delete_url, data="this is not json", content_type="application/json"
         )
-        self.assertEqual(response.status_code, 400) # HttpResponseBadRequest("Invalid JSON.")
+        self.assertEqual(
+            response.status_code, 400
+        )  # HttpResponseBadRequest("Invalid JSON.")
         # The response from HttpResponseBadRequest is not JSON, so no .json()
         self.assertIn("Invalid JSON", response.content.decode())
         self.assertEqual(ShoppingListItem.objects.count(), 1)

--- a/shopping_list/tests/test_ingredient_history_view.py
+++ b/shopping_list/tests/test_ingredient_history_view.py
@@ -12,7 +12,9 @@ from shopping_list.models.ingredient_history import IngredientHistory
 
 class IngredientHistoryViewTests(TestCase):
     def setUp(self):
-        self.user = User.objects.create_user(username="tester", password="pass")
+        self.user = User.objects.create_user(
+            username="tester", password="pass", is_staff=True
+        )
         self.client = Client()
         self.client.login(username="tester", password="pass")
 


### PR DESCRIPTION
## Summary
- add middleware that restricts modules to staff users
- enable the new middleware in Django settings
- update shopping list tests to login with staff accounts

## Testing
- `poetry run pytest -q` *(fails: IngredientHistoryViewTests::test_last_month_filter)*

------
https://chatgpt.com/codex/tasks/task_e_686d448348548329aec98afbe6923020