### PR TITLE
Add champion list page and improve random picker UI

### DIFF
--- a/runeterra/templates/runeterra/champion_list.html
+++ b/runeterra/templates/runeterra/champion_list.html
@@ -1,0 +1,73 @@
+{% extends 'runeterra/base.html' %}
+
+{% block title %}Champions{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Champions</h1>
+<form method="get" class="row g-3 mb-4">
+    <div class="col-md-3">
+        <label class="form-label" for="region">Region</label>
+        <select name="region" id="region" class="form-select">
+            <option value="">All regions</option>
+            {% for value, label in regions.choices %}
+                <option value="{{ value }}" {% if request.GET.region == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label" for="starLevel">Min star level</label>
+        <input type="number" min="0" max="6" name="star_level" id="starLevel" class="form-control" value="{{ request.GET.star_level }}">
+    </div>
+    <div class="col-md-2 d-flex align-items-end">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="only_unlocked" id="onlyUnlocked" {% if request.GET.only_unlocked %}checked{% endif %}>
+            <label class="form-check-label" for="onlyUnlocked">Unlocked</label>
+        </div>
+    </div>
+    <div class="col-md-2 d-flex align-items-end">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="only_lvl30" id="onlyLvl30" {% if request.GET.only_lvl30 %}checked{% endif %}>
+            <label class="form-check-label" for="onlyLvl30">Level 30</label>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label" for="sort">Sort by</label>
+        <select name="sort" id="sort" class="form-select">
+            <option value="name" {% if request.GET.sort == 'name' %}selected{% endif %}>Alphabetical</option>
+            <option value="star_level" {% if request.GET.sort == 'star_level' %}selected{% endif %}>Star level</option>
+        </select>
+    </div>
+    <div class="col-md-1 d-flex align-items-end">
+        <button type="submit" class="btn btn-primary w-100">Filter</button>
+    </div>
+</form>
+
+{% if champions %}
+<table class="table table-striped">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Primary Region</th>
+        <th>Secondary Region</th>
+        <th>Stars</th>
+        <th>Unlocked</th>
+        <th>Lvl30</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for champion in champions %}
+    <tr>
+        <td>{{ champion.name }}</td>
+        <td>{{ champion.get_primary_region_display }}</td>
+        <td>{{ champion.get_secondary_region_display }}</td>
+        <td>{{ champion.star_level }}</td>
+        <td>{{ champion.unlocked|yesno:'✓,✗' }}</td>
+        <td>{{ champion.lvl30|yesno:'✓,✗' }}</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>No champions found.</p>
+{% endif %}
+{% endblock %}

--- a/runeterra/templates/runeterra/header.html
+++ b/runeterra/templates/runeterra/header.html
@@ -4,5 +4,13 @@
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
             <span class="navbar-toggler-icon"></span>
         </button>
+        <ul class="navbar-nav me-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'runeterra:random_picker' %}">Random Picker</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'runeterra:champion_list' %}">Champions</a>
+            </li>
+        </ul>
     </div>
 </nav>

--- a/runeterra/templates/runeterra/random_picker.html
+++ b/runeterra/templates/runeterra/random_picker.html
@@ -4,64 +4,73 @@
 
 {% block content %}
     <h1 class="mb-4">Random Champion Picker</h1>
-    <form method="post">
-        {% csrf_token %}
-        <div class="form-check mb-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                name="only_unlocked"
-                id="onlyUnlocked"
-                {% if only_unlocked %}checked{% endif %}
-            >
-            <label class="form-check-label" for="onlyUnlocked">
-                Only unlocked
-            </label>
+    <div class="row">
+        <div class="col-md-4">
+            <form method="post" class="mb-4">
+                {% csrf_token %}
+                <div class="form-check mb-2">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        name="only_unlocked"
+                        id="onlyUnlocked"
+                        {% if only_unlocked %}checked{% endif %}
+                    >
+                    <label class="form-check-label" for="onlyUnlocked">
+                        Only unlocked
+                    </label>
+                </div>
+                <div class="form-check mb-3">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        name="only_lvl30"
+                        id="onlyLvl30"
+                        {% if only_lvl30 %}checked{% endif %}
+                    >
+                    <label class="form-check-label" for="onlyLvl30">
+                        Only level 30
+                    </label>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="region">Region</label>
+                    <select name="region" id="region" class="form-select">
+                        <option value="">All regions</option>
+                        {% for value, label in regions.choices %}
+                            <option value="{{ value }}" {% if selected_region == value %}selected{% endif %}>{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="minStarLevel">Minimum star level</label>
+                    <input
+                        type="number"
+                        name="min_star_level"
+                        id="minStarLevel"
+                        class="form-control"
+                        min="0"
+                        max="6"
+                        value="{{ min_star_level }}"
+                    >
+                </div>
+                <button type="submit" class="btn btn-primary">Pick a Champion</button>
+            </form>
         </div>
-        <div class="form-check mb-3">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                name="only_lvl30"
-                id="onlyLvl30"
-                {% if only_lvl30 %}checked{% endif %}
-            >
-            <label class="form-check-label" for="onlyLvl30">
-                Only level 30
-            </label>
-        </div>
-        <div class="mb-3">
-            <label class="form-label" for="region">Region</label>
-            <select name="region" id="region" class="form-select">
-                <option value="">All regions</option>
-                {% for value, label in regions.choices %}
-                    <option value="{{ value }}" {% if selected_region == value %}selected{% endif %}>{{ label }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="mb-3">
-            <label class="form-label" for="minStarLevel">Minimum star level</label>
-            <input
-                type="number"
-                name="min_star_level"
-                id="minStarLevel"
-                class="form-control"
-                min="0"
-                max="6"
-                value="{{ min_star_level }}"
-            >
-        </div>
-        <button type="submit" class="btn btn-primary">Pick a Champion</button>
-    </form>
-
-    {% if champion %}
-        <div class="mt-4">
-            <h3>{{ champion.name }}</h3>
-            <p>Primary Region: {{ champion.get_primary_region_display }}</p>
-            {% if champion.secondary_region %}
-                <p>Secondary Region: {{ champion.get_secondary_region_display }}</p>
+        <div class="col-md-8">
+            {% if champion %}
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="card-title">{{ champion.name }}</h3>
+                        <p class="card-text">Primary Region: {{ champion.get_primary_region_display }}</p>
+                        {% if champion.secondary_region %}
+                            <p class="card-text">Secondary Region: {{ champion.get_secondary_region_display }}</p>
+                        {% endif %}
+                        <p class="card-text">Star Level: {{ champion.star_level }}</p>
+                    </div>
+                </div>
+            {% elif request.method == 'POST' %}
+                <p class="mt-4">No champion matches your criteria.</p>
             {% endif %}
-            <p>Star Level: {{ champion.star_level }}</p>
         </div>
-    {% endif %}
+    </div>
 {% endblock %}

--- a/runeterra/urls.py
+++ b/runeterra/urls.py
@@ -6,4 +6,5 @@ app_name = "runeterra"
 
 urlpatterns = [
     path("", views.random_picker, name="random_picker"),
+    path("champions/", views.champion_list, name="champion_list"),
 ]

--- a/runeterra/views.py
+++ b/runeterra/views.py
@@ -49,3 +49,42 @@ def random_picker(request):
             "regions": Region,
         },
     )
+
+
+def champion_list(request):
+    champions = Champion.objects.all()
+
+    region = request.GET.get("region", "")
+    star_level = request.GET.get("star_level")
+    only_unlocked = request.GET.get("only_unlocked") is not None
+    only_lvl30 = request.GET.get("only_lvl30") is not None
+    sort = request.GET.get("sort", "name")
+
+    if region:
+        champions = champions.filter(
+            Q(primary_region=region) | Q(secondary_region=region)
+        )
+    if star_level:
+        try:
+            star_level_value = int(star_level)
+            champions = champions.filter(star_level__gte=star_level_value)
+        except (TypeError, ValueError):
+            pass
+    if only_unlocked:
+        champions = champions.filter(unlocked=True)
+    if only_lvl30:
+        champions = champions.filter(lvl30=True)
+
+    if sort == "star_level":
+        champions = champions.order_by("-star_level", "name")
+    else:
+        champions = champions.order_by("name")
+
+    return render(
+        request,
+        "runeterra/champion_list.html",
+        {
+            "champions": champions,
+            "regions": Region,
+        },
+    )


### PR DESCRIPTION
## Summary
- add a dedicated Champion list view with filtering and sorting
- display not-found message in random picker and show result in card
- cleanly separate form and results in Random Picker
- expose new page in navigation bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68751b8b98648329ab970da4e93bbd33