### PR TITLE
Add champion management to Runeterra

### DIFF
--- a/runeterra/forms/champion.py
+++ b/runeterra/forms/champion.py
@@ -1,0 +1,34 @@
+from django import forms
+
+from runeterra.models import Champion
+from runeterra.constants.region import Region
+
+
+class ChampionForm(forms.ModelForm):
+    class Meta:
+        model = Champion
+        fields = [
+            "name",
+            "primary_region",
+            "secondary_region",
+            "star_level",
+            "unlocked",
+            "lvl30",
+        ]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": "form-control"}),
+            "primary_region": forms.Select(attrs={"class": "form-select"}),
+            "secondary_region": forms.Select(attrs={"class": "form-select"}),
+            "star_level": forms.NumberInput(attrs={"class": "form-control", "min": 0, "max": 6}),
+            "unlocked": forms.CheckboxInput(attrs={"class": "form-check-input"}),
+            "lvl30": forms.CheckboxInput(attrs={"class": "form-check-input"}),
+        }
+        labels = {
+            "name": "Name",
+            "primary_region": "Primary region",
+            "secondary_region": "Secondary region",
+            "star_level": "Star level",
+            "unlocked": "Unlocked",
+            "lvl30": "Level 30",
+        }
+

--- a/runeterra/templates/runeterra/champion_form.html
+++ b/runeterra/templates/runeterra/champion_form.html
@@ -1,0 +1,13 @@
+{% extends 'runeterra/base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>{% if form.instance.pk %}Edit Champion{% else %}Add Champion{% endif %}</h2>
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="btn btn-success">Save</button>
+        <a href="{% url 'runeterra:champion_list' %}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+{% endblock %}

--- a/runeterra/templates/runeterra/champion_list.html
+++ b/runeterra/templates/runeterra/champion_list.html
@@ -3,7 +3,10 @@
 {% block title %}Champions{% endblock %}
 
 {% block content %}
-<h1 class="mb-4">Champions</h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Champions</h1>
+    <a class="btn btn-primary" href="{% url 'runeterra:champion_create' %}">➕ Add Champion</a>
+</div>
 <form method="get" class="row g-3 mb-4">
     <div class="col-md-3">
         <label class="form-label" for="region">Region</label>
@@ -52,6 +55,7 @@
         <th>Stars</th>
         <th>Unlocked</th>
         <th>Lvl30</th>
+        <th></th>
     </tr>
     </thead>
     <tbody>
@@ -63,7 +67,63 @@
         <td>{{ champion.star_level }}</td>
         <td>{{ champion.unlocked|yesno:'✓,✗' }}</td>
         <td>{{ champion.lvl30|yesno:'✓,✗' }}</td>
+        <td>
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#editChampionModal{{ champion.id }}">🖊️</button>
+        </td>
     </tr>
+    <!-- Edit Modal -->
+    <div class="modal fade" id="editChampionModal{{ champion.id }}" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Edit {{ champion.name }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <form method="post" action="{% url 'runeterra:champion_update' champion.id %}">
+                    {% csrf_token %}
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label" for="id_name_{{ champion.id }}">Name</label>
+                            <input type="text" class="form-control" id="id_name_{{ champion.id }}" name="name" value="{{ champion.name }}">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="id_primary_region_{{ champion.id }}">Primary Region</label>
+                            <select class="form-select" id="id_primary_region_{{ champion.id }}" name="primary_region">
+                                {% for value, label in regions.choices %}
+                                    <option value="{{ value }}" {% if champion.primary_region == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="id_secondary_region_{{ champion.id }}">Secondary Region</label>
+                            <select class="form-select" id="id_secondary_region_{{ champion.id }}" name="secondary_region">
+                                <option value=""></option>
+                                {% for value, label in regions.choices %}
+                                    <option value="{{ value }}" {% if champion.secondary_region == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="id_star_level_{{ champion.id }}">Star Level</label>
+                            <input type="number" min="0" max="6" class="form-control" id="id_star_level_{{ champion.id }}" name="star_level" value="{{ champion.star_level }}">
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="id_unlocked_{{ champion.id }}" name="unlocked" {% if champion.unlocked %}checked{% endif %}>
+                            <label class="form-check-label" for="id_unlocked_{{ champion.id }}">Unlocked</label>
+                        </div>
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="id_lvl30_{{ champion.id }}" name="lvl30" {% if champion.lvl30 %}checked{% endif %}>
+                            <label class="form-check-label" for="id_lvl30_{{ champion.id }}">Level 30</label>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
     {% endfor %}
     </tbody>
 </table>

--- a/runeterra/urls.py
+++ b/runeterra/urls.py
@@ -7,4 +7,6 @@ app_name = "runeterra"
 urlpatterns = [
     path("", views.random_picker, name="random_picker"),
     path("champions/", views.champion_list, name="champion_list"),
+    path("champions/new/", views.ChampionCreateView.as_view(), name="champion_create"),
+    path("champions/<int:pk>/edit/", views.ChampionUpdateView.as_view(), name="champion_update"),
 ]

--- a/runeterra/views.py
+++ b/runeterra/views.py
@@ -1,8 +1,11 @@
 from django.db.models import Q
 from django.shortcuts import render
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, UpdateView
 
 from runeterra.models import Champion
 from runeterra.constants.region import Region
+from runeterra.forms.champion import ChampionForm
 
 
 def random_picker(request):
@@ -88,3 +91,17 @@ def champion_list(request):
             "regions": Region,
         },
     )
+
+
+class ChampionCreateView(CreateView):
+    model = Champion
+    form_class = ChampionForm
+    template_name = "runeterra/champion_form.html"
+    success_url = reverse_lazy("runeterra:champion_list")
+
+
+class ChampionUpdateView(UpdateView):
+    model = Champion
+    form_class = ChampionForm
+    template_name = "runeterra/champion_form.html"
+    success_url = reverse_lazy("runeterra:champion_list")


### PR DESCRIPTION
## Summary
- create `ChampionForm`
- add champion creation page using `ChampionCreateView`
- allow editing champions with `ChampionUpdateView`
- update URLs and list template to support creation and editing
- show edit modal via pencil icon on champions list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687bcc5f823083299296e9f6748fc07f