### PR TITLE
Update Altered landing page and deck stats filter

### DIFF
--- a/altered/forms/deck_filter.py
+++ b/altered/forms/deck_filter.py
@@ -10,3 +10,10 @@ class DeckFilterForm(forms.Form):
         label='Faction',
         widget=forms.Select(attrs={'class': 'form-select'})
     )
+
+    only_active = forms.BooleanField(
+        required=False,
+        label='Active deck only',
+        initial=True,
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'})
+    )

--- a/altered/templates/altered/deck_stats.html
+++ b/altered/templates/altered/deck_stats.html
@@ -9,6 +9,12 @@
             {{ form.faction.label_tag }}
             {{ form.faction|add_class:"form-select" }}
         </div>
+        <div class="col-auto d-flex align-items-center">
+            <div class="form-check">
+                {{ form.only_active }}
+                {{ form.only_active.label_tag }}
+            </div>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-primary">Filter</button>
         </div>

--- a/altered/templates/altered/home.html
+++ b/altered/templates/altered/home.html
@@ -1,7 +1,0 @@
-{% extends 'altered/base.html' %}
-{% block content %}
-    <div class="container py-5">
-        <h1 class="mb-4 text-center">Bienvenue sur le projet Altered {{ request.user.username }}</h1>
-    </div>
-
-{% endblock %}

--- a/altered/urls.py
+++ b/altered/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 
-from altered.views.home import home
 from altered.views import game_form_view
 from altered.views.deck_stats import deck_stats_view
 from altered.views.meta_stats import meta_stats_view
@@ -8,7 +7,7 @@ from altered.views.meta_stats import meta_stats_view
 app_name = "altered"
 
 urlpatterns = [
-    path("", home, name="home"),
+    path("", game_form_view, name="home"),
     path('game/', game_form_view, name='game_form'),
     path('decks/', deck_stats_view, name='deck_stats'),
     path('meta/', meta_stats_view, name='meta_stats'),

--- a/altered/views/deck_stats.py
+++ b/altered/views/deck_stats.py
@@ -6,12 +6,16 @@ from altered.services.deck_game_stats import DeckGameStatsService
 
 
 def deck_stats_view(request):
-    form = DeckFilterForm(request.GET)
+    form = DeckFilterForm(request.GET or {"only_active": True})
     faction = None
+    only_active = True
     if form.is_valid():
         faction = form.cleaned_data.get('faction') or None
+        only_active = form.cleaned_data.get('only_active')
 
     decks = Deck.objects.select_related('champion')
+    if only_active:
+        decks = decks.filter(is_active=True)
     if faction:
         decks = decks.filter(champion__faction=faction)
 

--- a/altered/views/home.py
+++ b/altered/views/home.py
@@ -1,5 +1,0 @@
-from django.shortcuts import render
-
-
-def home(request):
-    return render(request, "altered/home.html")


### PR DESCRIPTION
## Summary
- replace the home view with the Add Game form so `/altered/` displays the game form
- add `only_active` filter in deck stats form
- filter deck stats results using the new toggle and show it in the UI

## Testing
- `./.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb3c2779c83298d733292406565f3