### PR TITLE
Add champion level to Runeterra UI

### DIFF
--- a/runeterra/forms/champion.py
+++ b/runeterra/forms/champion.py
@@ -12,23 +12,23 @@ class ChampionForm(forms.ModelForm):
             "primary_region",
             "secondary_region",
             "star_level",
+            "champion_level",
             "unlocked",
-            "lvl30",
         ]
         widgets = {
             "name": forms.TextInput(attrs={"class": "form-control"}),
             "primary_region": forms.Select(attrs={"class": "form-select"}),
             "secondary_region": forms.Select(attrs={"class": "form-select"}),
             "star_level": forms.NumberInput(attrs={"class": "form-control", "min": 0, "max": 6}),
+            "champion_level": forms.NumberInput(attrs={"class": "form-control", "min": 0, "max": 60}),
             "unlocked": forms.CheckboxInput(attrs={"class": "form-check-input"}),
-            "lvl30": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
         labels = {
             "name": "Name",
             "primary_region": "Primary region",
             "secondary_region": "Secondary region",
             "star_level": "Star level",
+            "champion_level": "Level",
             "unlocked": "Unlocked",
-            "lvl30": "Level 30",
         }
 

--- a/runeterra/templates/runeterra/champion_list.html
+++ b/runeterra/templates/runeterra/champion_list.html
@@ -38,6 +38,7 @@
         <select name="sort" id="sort" class="form-select">
             <option value="name" {% if request.GET.sort == 'name' %}selected{% endif %}>Alphabetical</option>
             <option value="star_level" {% if request.GET.sort == 'star_level' %}selected{% endif %}>Star level</option>
+            <option value="level" {% if request.GET.sort == 'level' %}selected{% endif %}>Level</option>
         </select>
     </div>
     <div class="col-md-1 d-flex align-items-end">
@@ -53,8 +54,8 @@
         <th>Primary Region</th>
         <th>Secondary Region</th>
         <th>Stars</th>
+        <th>Level</th>
         <th>Unlocked</th>
-        <th>Lvl30</th>
         <th></th>
     </tr>
     </thead>
@@ -65,8 +66,8 @@
         <td>{{ champion.get_primary_region_display }}</td>
         <td>{{ champion.get_secondary_region_display }}</td>
         <td>{{ champion.star_level }}</td>
+        <td>{{ champion.champion_level }}</td>
         <td>{{ champion.unlocked|yesno:'✓,✗' }}</td>
-        <td>{{ champion.lvl30|yesno:'✓,✗' }}</td>
         <td>
             <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#editChampionModal{{ champion.id }}">🖊️</button>
         </td>
@@ -107,13 +108,13 @@
                             <label class="form-label" for="id_star_level_{{ champion.id }}">Star Level</label>
                             <input type="number" min="0" max="6" class="form-control" id="id_star_level_{{ champion.id }}" name="star_level" value="{{ champion.star_level }}">
                         </div>
+                        <div class="mb-3">
+                            <label class="form-label" for="id_champion_level_{{ champion.id }}">Level</label>
+                            <input type="number" min="0" max="60" class="form-control" id="id_champion_level_{{ champion.id }}" name="champion_level" value="{{ champion.champion_level }}">
+                        </div>
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="id_unlocked_{{ champion.id }}" name="unlocked" {% if champion.unlocked %}checked{% endif %}>
                             <label class="form-check-label" for="id_unlocked_{{ champion.id }}">Unlocked</label>
-                        </div>
-                        <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" id="id_lvl30_{{ champion.id }}" name="lvl30" {% if champion.lvl30 %}checked{% endif %}>
-                            <label class="form-check-label" for="id_lvl30_{{ champion.id }}">Level 30</label>
                         </div>
                     </div>
                     <div class="modal-footer">

--- a/runeterra/templates/runeterra/random_picker.html
+++ b/runeterra/templates/runeterra/random_picker.html
@@ -53,6 +53,30 @@
                         value="{{ min_star_level }}"
                     >
                 </div>
+                <div class="mb-3">
+                    <label class="form-label" for="minLevel">Min level</label>
+                    <input
+                        type="number"
+                        name="min_level"
+                        id="minLevel"
+                        class="form-control"
+                        min="0"
+                        max="60"
+                        value="{{ min_level }}"
+                    >
+                </div>
+                <div class="mb-3">
+                    <label class="form-label" for="maxLevel">Max level</label>
+                    <input
+                        type="number"
+                        name="max_level"
+                        id="maxLevel"
+                        class="form-control"
+                        min="0"
+                        max="60"
+                        value="{{ max_level }}"
+                    >
+                </div>
                 <button type="submit" class="btn btn-primary">Pick a Champion</button>
             </form>
         </div>
@@ -66,6 +90,7 @@
                             <p class="card-text">Secondary Region: {{ champion.get_secondary_region_display }}</p>
                         {% endif %}
                         <p class="card-text">Star Level: {{ champion.star_level }}</p>
+                        <p class="card-text">Level: {{ champion.champion_level }}</p>
                     </div>
                 </div>
             {% elif request.method == 'POST' %}

--- a/runeterra/templates/runeterra/region_stats.html
+++ b/runeterra/templates/runeterra/region_stats.html
@@ -10,7 +10,10 @@
         <th>Région</th>
         <th>Champions</th>
         <th>Débloqués</th>
+        <th>Mean Constellation Level Adjusted</th>
         <th>Niveau moyen</th>
+        <th>Niveau minimum</th>
+        <th>Niveau maximum</th>
     </tr>
     </thead>
     <tbody>
@@ -19,7 +22,10 @@
         <td>{{ row.label }}</td>
         <td>{{ row.total }}</td>
         <td>{{ row.unlocked }}</td>
-        <td>{{ row.avg|floatformat:2 }}</td>
+        <td>{{ row.constellation_mean|floatformat:2 }}</td>
+        <td>{{ row.level_mean|floatformat:2 }}</td>
+        <td>{{ row.level_min }}</td>
+        <td>{{ row.level_max }}</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/runeterra/views/champion.py
+++ b/runeterra/views/champion.py
@@ -34,6 +34,8 @@ def champion_list(request):
 
     if sort == "star_level":
         champions = champions.order_by("-star_level", "name")
+    elif sort == "level":
+        champions = champions.order_by("-champion_level", "name")
     else:
         champions = champions.order_by("name")
 

--- a/runeterra/views/random.py
+++ b/runeterra/views/random.py
@@ -11,6 +11,8 @@ def random_picker(request):
     only_lvl30 = False
     selected_region = ""
     min_star_level = 0
+    min_level = 0
+    max_level = 60
 
     if request.method == "POST":
         only_unlocked = bool(request.POST.get("only_unlocked"))
@@ -20,6 +22,14 @@ def random_picker(request):
             min_star_level = int(request.POST.get("min_star_level", 0))
         except (TypeError, ValueError):
             min_star_level = 0
+        try:
+            min_level = int(request.POST.get("min_level", 0))
+        except (TypeError, ValueError):
+            min_level = 0
+        try:
+            max_level = int(request.POST.get("max_level", 60))
+        except (TypeError, ValueError):
+            max_level = 60
 
         queryset = Champion.objects.all()
 
@@ -33,6 +43,10 @@ def random_picker(request):
             )
         if min_star_level:
             queryset = queryset.filter(star_level__gte=min_star_level)
+        if min_level:
+            queryset = queryset.filter(champion_level__gte=min_level)
+        if max_level:
+            queryset = queryset.filter(champion_level__lte=max_level)
 
         champion = queryset.order_by("?").first()
 
@@ -45,6 +59,8 @@ def random_picker(request):
             "only_lvl30": only_lvl30,
             "selected_region": selected_region,
             "min_star_level": min_star_level,
+            "min_level": min_level,
+            "max_level": max_level,
             "regions": Region,
         },
     )

--- a/runeterra/views/stats.py
+++ b/runeterra/views/stats.py
@@ -1,4 +1,4 @@
-from django.db.models import Avg, Case, F, IntegerField, Q, When
+from django.db.models import Avg, Case, F, IntegerField, Q, When, Min, Max
 from django.shortcuts import render
 
 from runeterra.constants.region import Region
@@ -11,7 +11,7 @@ def region_stats(request):
         qs = Champion.objects.filter(Q(primary_region=value) | Q(secondary_region=value))
         total = qs.count()
         unlocked = qs.filter(unlocked=True).count()
-        avg = (
+        constellation_mean = (
             qs.annotate(
                 effective=F("star_level")
                 + Case(When(lvl30=True, then=2), default=0, output_field=IntegerField())
@@ -20,6 +20,21 @@ def region_stats(request):
             .get("avg")
             or 0
         )
-        stats.append({"label": label, "total": total, "unlocked": unlocked, "avg": avg})
+        level_stats = qs.aggregate(
+            mean=Avg("champion_level"),
+            min=Min("champion_level"),
+            max=Max("champion_level"),
+        )
+        stats.append(
+            {
+                "label": label,
+                "total": total,
+                "unlocked": unlocked,
+                "constellation_mean": constellation_mean,
+                "level_mean": level_stats.get("mean") or 0,
+                "level_min": level_stats.get("min") or 0,
+                "level_max": level_stats.get("max") or 0,
+            }
+        )
 
     return render(request, "runeterra/region_stats.html", {"stats": stats})


### PR DESCRIPTION
## Summary
- show `champion_level` in champion forms and list
- allow sorting by level in champion list
- extend Random Picker with level range filters
- display level in random picker result
- enhance region stats with champion level metrics and rename adjusted constellation level

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687d0326443c8329bc4fd7725fcc82dd