### PR TITLE
Add unlocked filter and champion color coding

### DIFF
--- a/runeterra/templates/runeterra/champion_list.html
+++ b/runeterra/templates/runeterra/champion_list.html
@@ -61,7 +61,15 @@
     </thead>
     <tbody>
     {% for champion in champions %}
-    <tr>
+    <tr
+        {% if not champion.unlocked %}
+            class="table-danger"
+        {% elif champion.lvl30 %}
+            class="table-success"
+        {% else %}
+            class="table-warning"
+        {% endif %}
+    >
         <td>{{ champion.name }}</td>
         <td>{{ champion.get_primary_region_display }}</td>
         <td>{{ champion.get_secondary_region_display }}</td>

--- a/runeterra/templates/runeterra/region_stats.html
+++ b/runeterra/templates/runeterra/region_stats.html
@@ -4,6 +4,19 @@
 
 {% block content %}
 <h1 class="mb-4">Stats par région</h1>
+<form method="get" class="mb-3">
+    <div class="form-check">
+        <input
+            class="form-check-input"
+            type="checkbox"
+            name="only_unlocked"
+            id="onlyUnlocked"
+            {% if only_unlocked %}checked{% endif %}
+        >
+        <label class="form-check-label" for="onlyUnlocked">Only unlocked</label>
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Filter</button>
+</form>
 <table class="table table-striped">
     <thead>
     <tr>


### PR DESCRIPTION
## Summary
- add `only_unlocked` option for region stats
- show unlocked filter checkbox in stats page
- color code champions list rows based on unlocked and level 30

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687d061076b88329898fc9854dcef629