### PR TITLE
Display daily and hourly contraction stats

### DIFF
--- a/babyberon/templates/babyberon/contraction_stats.html
+++ b/babyberon/templates/babyberon/contraction_stats.html
@@ -2,8 +2,13 @@
 
 {% block content %}
 <h2 class="mb-4">Statistiques des contractions</h2>
-<div class="mb-4">
-    {{ chart_div|safe }}
+<div class="mb-5">
+    <h3 class="mb-3">Par jour (7 derniers jours)</h3>
+    {{ daily_chart_div|safe }}
+</div>
+<div class="mb-5">
+    <h3 class="mb-3">Par heure</h3>
+    {{ hourly_chart_div|safe }}
 </div>
 <div class="mb-3">
     <a href="{% url 'babyberon:contractions' %}" class="btn btn-primary">Ajouter une contraction</a>

--- a/babyberon/views/contraction.py
+++ b/babyberon/views/contraction.py
@@ -34,11 +34,15 @@ class ContractionController:
 
     @staticmethod
     def stats(request):
-        chart_div = ContractionStatsChartService.generate()
+        daily_chart_div = ContractionStatsChartService.generate_daily()
+        hourly_chart_div = ContractionStatsChartService.generate_hourly()
         return render(
             request,
             "babyberon/contraction_stats.html",
-            {"chart_div": chart_div},
+            {
+                "daily_chart_div": daily_chart_div,
+                "hourly_chart_div": hourly_chart_div,
+            },
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- keep existing daily contraction bar chart
- add hourly contraction line chart
- show both charts on stats page

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687e468909e08329a12f5fafca57237c