### PR TITLE
Add edit modal to random picker and tweak UI

### DIFF
--- a/runeterra/templates/runeterra/champion_edit_modal.html
+++ b/runeterra/templates/runeterra/champion_edit_modal.html
@@ -1,0 +1,52 @@
+<div class="modal fade" id="editChampionModal{{ champion.id }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit {{ champion.name }}</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" action="{% url 'runeterra:champion_update' champion.id %}">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label" for="id_name_{{ champion.id }}">Name</label>
+                        <input type="text" class="form-control" id="id_name_{{ champion.id }}" name="name" value="{{ champion.name }}">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="id_primary_region_{{ champion.id }}">Primary Region</label>
+                        <select class="form-select" id="id_primary_region_{{ champion.id }}" name="primary_region">
+                            {% for value, label in regions.choices %}
+                                <option value="{{ value }}" {% if champion.primary_region == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="id_secondary_region_{{ champion.id }}">Secondary Region</label>
+                        <select class="form-select" id="id_secondary_region_{{ champion.id }}" name="secondary_region">
+                            <option value=""></option>
+                            {% for value, label in regions.choices %}
+                                <option value="{{ value }}" {% if champion.secondary_region == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="id_star_level_{{ champion.id }}">Star Level</label>
+                        <input type="number" min="0" max="6" class="form-control" id="id_star_level_{{ champion.id }}" name="star_level" value="{{ champion.star_level }}">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label" for="id_champion_level_{{ champion.id }}">Level</label>
+                        <input type="number" min="0" max="60" class="form-control" id="id_champion_level_{{ champion.id }}" name="champion_level" value="{{ champion.champion_level }}">
+                    </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="id_unlocked_{{ champion.id }}" name="unlocked" {% if champion.unlocked %}checked{% endif %}>
+                        <label class="form-check-label" for="id_unlocked_{{ champion.id }}">Unlocked</label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/runeterra/templates/runeterra/champion_list.html
+++ b/runeterra/templates/runeterra/champion_list.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1 class="mb-0">Champions</h1>
+    <h1 class="mb-0">Champions 🏆</h1>
     <a class="btn btn-primary" href="{% url 'runeterra:champion_create' %}">➕ Add Champion</a>
 </div>
 <form method="get" class="row g-3 mb-4">
@@ -53,7 +53,7 @@
         <th>Name</th>
         <th>Primary Region</th>
         <th>Secondary Region</th>
-        <th>Stars</th>
+        <th>Stars ⭐</th>
         <th>Level</th>
         <th></th>
     </tr>
@@ -72,65 +72,13 @@
         <td>{{ champion.name }}</td>
         <td>{{ champion.get_primary_region_display }}</td>
         <td>{{ champion.get_secondary_region_display }}</td>
-        <td>{{ champion.star_level }}</td>
+        <td>{{ champion.star_level }} ⭐</td>
         <td>{{ champion.champion_level }}</td>
         <td>
             <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#editChampionModal{{ champion.id }}">🖊️</button>
         </td>
     </tr>
-    <!-- Edit Modal -->
-    <div class="modal fade" id="editChampionModal{{ champion.id }}" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Edit {{ champion.name }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <form method="post" action="{% url 'runeterra:champion_update' champion.id %}">
-                    {% csrf_token %}
-                    <div class="modal-body">
-                        <div class="mb-3">
-                            <label class="form-label" for="id_name_{{ champion.id }}">Name</label>
-                            <input type="text" class="form-control" id="id_name_{{ champion.id }}" name="name" value="{{ champion.name }}">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="id_primary_region_{{ champion.id }}">Primary Region</label>
-                            <select class="form-select" id="id_primary_region_{{ champion.id }}" name="primary_region">
-                                {% for value, label in regions.choices %}
-                                    <option value="{{ value }}" {% if champion.primary_region == value %}selected{% endif %}>{{ label }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="id_secondary_region_{{ champion.id }}">Secondary Region</label>
-                            <select class="form-select" id="id_secondary_region_{{ champion.id }}" name="secondary_region">
-                                <option value=""></option>
-                                {% for value, label in regions.choices %}
-                                    <option value="{{ value }}" {% if champion.secondary_region == value %}selected{% endif %}>{{ label }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="id_star_level_{{ champion.id }}">Star Level</label>
-                            <input type="number" min="0" max="6" class="form-control" id="id_star_level_{{ champion.id }}" name="star_level" value="{{ champion.star_level }}">
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label" for="id_champion_level_{{ champion.id }}">Level</label>
-                            <input type="number" min="0" max="60" class="form-control" id="id_champion_level_{{ champion.id }}" name="champion_level" value="{{ champion.champion_level }}">
-                        </div>
-                        <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" id="id_unlocked_{{ champion.id }}" name="unlocked" {% if champion.unlocked %}checked{% endif %}>
-                            <label class="form-check-label" for="id_unlocked_{{ champion.id }}">Unlocked</label>
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <button type="submit" class="btn btn-primary">Save</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
+    {% include 'runeterra/champion_edit_modal.html' %}
     {% endfor %}
     </tbody>
 </table>

--- a/runeterra/templates/runeterra/header.html
+++ b/runeterra/templates/runeterra/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light px-3">
     <div class="container-fluid">
-        <a class="navbar-brand" href="{% url 'runeterra:random_picker' %}">Runeterra</a>
+        <a class="navbar-brand" href="{% url 'runeterra:random_picker' %}">Runeterra ⚔️</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/runeterra/templates/runeterra/random_picker.html
+++ b/runeterra/templates/runeterra/random_picker.html
@@ -3,7 +3,7 @@
 {% block title %}Random Picker{% endblock %}
 
 {% block content %}
-    <h1 class="mb-4">Random Champion Picker</h1>
+    <h1 class="mb-4">Random Champion Picker 🎲</h1>
     <div class="row">
         <div class="col-md-4">
             <form method="post" class="mb-4">
@@ -84,15 +84,19 @@
             {% if champion %}
                 <div class="card">
                     <div class="card-body">
-                        <h3 class="card-title">{{ champion.name }}</h3>
+                        <div class="d-flex justify-content-between align-items-start">
+                            <h3 class="card-title mb-0">{{ champion.name }}</h3>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#editChampionModal{{ champion.id }}">🖊️</button>
+                        </div>
                         <p class="card-text">Primary Region: {{ champion.get_primary_region_display }}</p>
                         {% if champion.secondary_region %}
                             <p class="card-text">Secondary Region: {{ champion.get_secondary_region_display }}</p>
                         {% endif %}
-                        <p class="card-text">Star Level: {{ champion.star_level }}</p>
+                        <p class="card-text">Star Level: {{ champion.star_level }} ⭐</p>
                         <p class="card-text">Level: {{ champion.champion_level }}</p>
                     </div>
                 </div>
+                {% include 'runeterra/champion_edit_modal.html' %}
             {% elif request.method == 'POST' %}
                 <p class="mt-4">No champion matches your criteria.</p>
             {% endif %}


### PR DESCRIPTION
## Summary
- reuse champion edit modal in a new partial template
- include modal on champion list and random picker pages
- add edit button to random picker results
- sprinkle a few emojis for a more cheerful UI

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68810b4dc1b08329b25601ec097cd4c7