### PR TITLE
Implement additional sorting and metrics on Unique Flips

### DIFF
--- a/altered/forms/unique_flip.py
+++ b/altered/forms/unique_flip.py
@@ -22,4 +22,9 @@ class UniqueFlipFilterForm(forms.Form):
         label='Faction',
         widget=forms.Select(attrs={'class': 'form-select'})
     )
+    hide_zero = forms.BooleanField(
+        required=False,
+        label='Hide 0 buy price',
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'})
+    )
 

--- a/altered/models/unique_flip.py
+++ b/altered/models/unique_flip.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.db import models
 from django.contrib import admin
 
@@ -31,7 +33,7 @@ class UniqueFlip(models.Model):
     @property
     def balance(self):
         sold = self.sold_price or 0
-        return sold - self.bought_price
+        return (sold * Decimal('0.95')) - self.bought_price
 
     @property
     def balance_percentage(self):

--- a/altered/models/unique_flip.py
+++ b/altered/models/unique_flip.py
@@ -33,6 +33,12 @@ class UniqueFlip(models.Model):
         sold = self.sold_price or 0
         return sold - self.bought_price
 
+    @property
+    def balance_percentage(self):
+        if self.bought_price == 0:
+            return None
+        return (self.balance / self.bought_price) * 100
+
 
 @admin.register(UniqueFlip)
 class UniqueFlipAdmin(admin.ModelAdmin):

--- a/altered/templates/altered/unique_flip_list.html
+++ b/altered/templates/altered/unique_flip_list.html
@@ -65,6 +65,10 @@
                 {{ filter_form.faction.label_tag }}
                 {{ filter_form.faction|add_class:"form-select" }}
             </div>
+            <div class="col-auto form-check">
+                {{ filter_form.hide_zero }}
+                <label class="form-check-label" for="{{ filter_form.hide_zero.id_for_label }}">{{ filter_form.hide_zero.label }}</label>
+            </div>
             <div class="col-auto">
                 <button type="submit" class="btn btn-primary">Filtrer</button>
             </div>
@@ -77,8 +81,19 @@
                 <th>Unique Id</th>
                 <th>Détail</th>
                 {% if status == 'sold' %}
-                    <th>Balance</th>
-                    <th>Prix achat</th>
+                    <th>
+                        <a href="?status={{ status }}{% if selected_faction %}&faction={{ selected_faction }}{% endif %}{% if hide_zero %}&hide_zero=on{% endif %}&sort={% if sort == 'balance' %}-balance{% else %}balance{% endif %}">
+                            Balance
+                            {% if sort == 'balance' %}▲{% elif sort == '-balance' %}▼{% endif %}
+                        </a>
+                    </th>
+                    <th>
+                        <a href="?status={{ status }}{% if selected_faction %}&faction={{ selected_faction }}{% endif %}{% if hide_zero %}&hide_zero=on{% endif %}&sort={% if sort == 'bought_price' %}-bought_price{% else %}bought_price{% endif %}">
+                            Prix achat
+                            {% if sort == 'bought_price' %}▲{% elif sort == '-bought_price' %}▼{% endif %}
+                        </a>
+                    </th>
+                    <th>Balance %</th>
                     <th>Prix vente</th>
                 {% else %}
                     <th>En cours d'utilisation</th>
@@ -99,6 +114,7 @@
                     {% if status == 'sold' %}
                         <td>{{ flip.balance }}</td>
                         <td>{{ flip.bought_price }}</td>
+                        <td>{{ flip.balance_percentage|default_if_none:''|floatformat:2 }}{% if flip.balance_percentage is not None %}%{% endif %}</td>
                         <td>{{ flip.sold_price }}</td>
                     {% else %}
                         <td>
@@ -147,7 +163,7 @@
                 </tr>
             {% empty %}
                 <tr>
-                    <td colspan="6" class="text-center">No data.</td>
+                    <td colspan="{% if status == 'sold' %}7{% else %}6{% endif %}" class="text-center">No data.</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/altered/views/unique_flip.py
+++ b/altered/views/unique_flip.py
@@ -13,10 +13,13 @@ from altered.forms import (
 
 def unique_flip_list_view(request):
     status = request.GET.get('status', 'current')
+    sort = request.GET.get('sort')
     filter_form = UniqueFlipFilterForm(request.GET)
     faction = None
+    hide_zero = False
     if filter_form.is_valid():
         faction = filter_form.cleaned_data.get('faction') or None
+        hide_zero = filter_form.cleaned_data.get('hide_zero')
 
     if request.method == 'POST':
         if 'purchase' in request.POST:
@@ -44,15 +47,35 @@ def unique_flip_list_view(request):
     else:
         form = UniqueFlipPurchaseForm()
 
-    flips = UniqueFlip.objects.order_by('-bought_at')
+    flips = UniqueFlip.objects.all()
     if status == 'sold':
         flips = flips.filter(sold_at__isnull=False)
     else:
         flips = flips.filter(sold_at__isnull=True)
     if faction:
         flips = flips.filter(faction=faction)
+    if hide_zero:
+        flips = flips.exclude(bought_price=0)
 
-    balance = UniqueFlip.objects.filter(in_use=False).aggregate(
+    balance_expression = ExpressionWrapper(
+        Coalesce(F('sold_price'), 0) - F('bought_price'),
+        output_field=DecimalField(max_digits=10, decimal_places=2),
+    )
+
+    if sort in ('bought_price', '-bought_price'):
+        flips = flips.order_by(sort)
+    elif sort in ('balance', '-balance'):
+        order_field = ('-' if sort.startswith('-') else '') + 'balance_value'
+        flips = flips.annotate(balance_value=balance_expression).order_by(order_field)
+    else:
+        flips = flips.order_by('-bought_at')
+
+    flips = flips.annotate(balance_value=balance_expression)
+
+    balance_queryset = UniqueFlip.objects.filter(in_use=False)
+    if hide_zero:
+        balance_queryset = balance_queryset.exclude(bought_price=0)
+    balance = balance_queryset.aggregate(
         balance=Sum(
             ExpressionWrapper(
                 Coalesce(F('sold_price'), 0) - F('bought_price'),
@@ -66,6 +89,8 @@ def unique_flip_list_view(request):
         'status': status,
         'selected_faction': faction,
         'balance': balance,
+        'hide_zero': hide_zero,
+        'sort': sort,
         'purchase_form': form,
         'sell_form': UniqueFlipSellForm(),
         'filter_form': filter_form,

--- a/altered/views/unique_flip.py
+++ b/altered/views/unique_flip.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.db.models import Sum, F, DecimalField, ExpressionWrapper
 from django.db.models.functions import Coalesce
 from django.shortcuts import render, redirect, get_object_or_404
@@ -58,7 +60,7 @@ def unique_flip_list_view(request):
         flips = flips.exclude(bought_price=0)
 
     balance_expression = ExpressionWrapper(
-        Coalesce(F('sold_price'), 0) - F('bought_price'),
+        (Coalesce(F('sold_price'), 0) * Decimal('0.95')) - F('bought_price'),
         output_field=DecimalField(max_digits=10, decimal_places=2),
     )
 
@@ -78,7 +80,7 @@ def unique_flip_list_view(request):
     balance = balance_queryset.aggregate(
         balance=Sum(
             ExpressionWrapper(
-                Coalesce(F('sold_price'), 0) - F('bought_price'),
+                (Coalesce(F('sold_price'), 0) * Decimal('0.95')) - F('bought_price'),
                 output_field=DecimalField(max_digits=10, decimal_places=2),
             )
         )


### PR DESCRIPTION
## Summary
- allow filtering UniqueFlips with zero buy price removed
- add sorting by bought price or balance
- show balance percentage for sold flips
- update template with sort links and filter checkbox

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68835ada04108329aac7b9f5ad9975fe