### PR TITLE
Add Career page with champion win stats

### DIFF
--- a/altered/forms/__init__.py
+++ b/altered/forms/__init__.py
@@ -1,4 +1,5 @@
 from .new_game import GameForm
+from .career_filter import CareerFilterForm
 from .unique_flip import (
     UniqueFlipPurchaseForm,
     UniqueFlipSellForm,
@@ -7,6 +8,7 @@ from .unique_flip import (
 
 __all__ = [
     'GameForm',
+    'CareerFilterForm',
     'UniqueFlipPurchaseForm',
     'UniqueFlipSellForm',
     'UniqueFlipFilterForm',

--- a/altered/forms/career_filter.py
+++ b/altered/forms/career_filter.py
@@ -1,0 +1,22 @@
+from django import forms
+
+from altered.constants.faction import Faction
+
+
+class CareerFilterForm(forms.Form):
+    faction = forms.ChoiceField(
+        choices=[('', 'All Factions')] + Faction.choices,
+        required=False,
+        label='Faction',
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    name = forms.CharField(
+        required=False,
+        label='Champion name',
+        widget=forms.TextInput(attrs={'class': 'form-control'})
+    )
+    only_missing = forms.BooleanField(
+        required=False,
+        label='Missing only',
+        widget=forms.CheckboxInput(attrs={'class': 'form-check-input'})
+    )

--- a/altered/services/career_stats.py
+++ b/altered/services/career_stats.py
@@ -1,0 +1,24 @@
+from altered.models import Champion, Game
+from altered.value_objects.career_champion_stats import CareerChampionStats
+
+
+class CareerStatsService:
+    def __init__(self, faction: str | None = None, name: str | None = None, missing_only: bool = False):
+        self.faction = faction
+        self.name = name
+        self.missing_only = missing_only
+        self.result: list[CareerChampionStats] = []
+        self.compute()
+
+    def compute(self):
+        champions = Champion.objects.all()
+        if self.faction:
+            champions = champions.filter(faction=self.faction)
+        if self.name:
+            champions = champions.filter(name__icontains=self.name)
+        champions = champions.order_by('name')
+        for champion in champions:
+            win_number = Game.objects.filter(opponent_champion=champion, is_win=True).count()
+            if self.missing_only and win_number > 0:
+                continue
+            self.result.append(CareerChampionStats(champion=champion, win_number=win_number))

--- a/altered/templates/altered/career.html
+++ b/altered/templates/altered/career.html
@@ -1,0 +1,50 @@
+{% extends 'altered/base.html' %}
+{% load form_filters %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Career</h2>
+    <form method="get" class="row mb-3 g-2 align-items-end">
+        <div class="col-auto">
+            {{ form.faction.label_tag }}
+            {{ form.faction|add_class:"form-select" }}
+        </div>
+        <div class="col-auto">
+            {{ form.name.label_tag }}
+            {{ form.name|add_class:"form-control" }}
+        </div>
+        <div class="col-auto d-flex align-items-center">
+            <div class="form-check">
+                {{ form.only_missing }}
+                {{ form.only_missing.label_tag }}
+            </div>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+    </form>
+
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Champion</th>
+            <th>Faction</th>
+            <th>Wins</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for stat in stats %}
+            <tr {% if stat.win_number == 0 %}style="background-color: #f8d7da;"{% elif stat.win_number >= 25 %}style="background-color: gold;"{% elif stat.win_number >= 10 %}style="background-color: silver;"{% elif stat.win_number >= 5 %}style="background-color: #cd7f32;"{% endif %}>
+                <td>{{ stat.champion.name }}</td>
+                <td>{{ stat.champion.faction }}</td>
+                <td>{{ stat.win_number }}</td>
+            </tr>
+        {% empty %}
+            <tr>
+                <td colspan="3" class="text-center">No data available.</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/altered/templates/altered/header.html
+++ b/altered/templates/altered/header.html
@@ -16,6 +16,9 @@
                     <a class="nav-link" href="{% url 'altered:meta_stats' %}">Meta Stats</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="{% url 'altered:career' %}">Career</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="{% url 'altered:unique_flip_list' %}">Unique Flips</a>
                 </li>
             </ul>

--- a/altered/tests/test_career_stats_service.py
+++ b/altered/tests/test_career_stats_service.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from altered.models import Champion, Deck, Game
+from altered.services.career_stats import CareerStatsService
+
+
+class CareerStatsServiceTests(TestCase):
+    def setUp(self):
+        self.champ1 = Champion.objects.create(name="Alpha", faction="AXIOM")
+        self.champ2 = Champion.objects.create(name="Beta", faction="BRAVOS")
+        self.champ3 = Champion.objects.create(name="Gamma", faction="LYRA")
+        self.deck = Deck.objects.create(name="Deck1", champion=self.champ1, altered_id="1")
+        Game.objects.create(deck=self.deck, opponent_champion=self.champ2, is_win=True)
+        Game.objects.create(deck=self.deck, opponent_champion=self.champ2, is_win=False)
+        Game.objects.create(deck=self.deck, opponent_champion=self.champ2, is_win=True)
+
+    def test_compute_win_numbers(self):
+        service = CareerStatsService()
+        beta_stat = next(s for s in service.result if s.champion == self.champ2)
+        self.assertEqual(beta_stat.win_number, 2)
+        alpha_stat = next(s for s in service.result if s.champion == self.champ1)
+        self.assertEqual(alpha_stat.win_number, 0)
+
+    def test_missing_only_filter(self):
+        service = CareerStatsService(missing_only=True)
+        champs = [stat.champion for stat in service.result]
+        self.assertIn(self.champ1, champs)
+        self.assertIn(self.champ3, champs)
+        self.assertNotIn(self.champ2, champs)

--- a/altered/urls.py
+++ b/altered/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from altered.views import game_form_view
 from altered.views.deck_stats import deck_stats_view
 from altered.views.meta_stats import meta_stats_view
+from altered.views.career import career_view
 from altered.views.unique_flip import (
     unique_flip_list_view,
     unique_flip_detail_view,
@@ -15,6 +16,7 @@ urlpatterns = [
     path('game/', game_form_view, name='game_form'),
     path('decks/', deck_stats_view, name='deck_stats'),
     path('meta/', meta_stats_view, name='meta_stats'),
+    path('career/', career_view, name='career'),
     path('flips/', unique_flip_list_view, name='unique_flip_list'),
     path('flips/<int:flip_id>/', unique_flip_detail_view, name='unique_flip_detail'),
 ]

--- a/altered/value_objects/__init__.py
+++ b/altered/value_objects/__init__.py
@@ -1,2 +1,3 @@
 from .deck_game_stats import DeckGameStats
 from .champion_game_stats import ChampionGameStats
+from .career_champion_stats import CareerChampionStats

--- a/altered/value_objects/career_champion_stats.py
+++ b/altered/value_objects/career_champion_stats.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from altered.models import Champion
+
+
+@dataclass
+class CareerChampionStats:
+    champion: Champion
+    win_number: int = 0

--- a/altered/views/career.py
+++ b/altered/views/career.py
@@ -1,0 +1,21 @@
+from django.shortcuts import render
+
+from altered.forms.career_filter import CareerFilterForm
+from altered.services.career_stats import CareerStatsService
+
+
+def career_view(request):
+    form = CareerFilterForm(request.GET)
+    faction = None
+    name = None
+    only_missing = False
+    if form.is_valid():
+        faction = form.cleaned_data.get('faction') or None
+        name = form.cleaned_data.get('name') or None
+        only_missing = form.cleaned_data.get('only_missing')
+    service = CareerStatsService(faction=faction, name=name, missing_only=only_missing)
+    context = {
+        'stats': service.result,
+        'form': form,
+    }
+    return render(request, 'altered/career.html', context)


### PR DESCRIPTION
## Summary
- create `CareerStatsService` and dataclass
- add filter form for faction/name/missing champs
- expose career stats view and template with color-coded wins
- link new page in navigation
- test new service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688872b6e0608329839c82daf0806192