### PR TITLE
Fix champion career stats

### DIFF
--- a/altered/services/career_stats.py
+++ b/altered/services/career_stats.py
@@ -18,7 +18,7 @@ class CareerStatsService:
             champions = champions.filter(name__icontains=self.name)
         champions = champions.order_by('name')
         for champion in champions:
-            win_number = Game.objects.filter(opponent_champion=champion, is_win=True).count()
+            win_number = Game.objects.filter(deck__champion=champion, is_win=True).count()
             if self.missing_only and win_number > 0:
                 continue
             self.result.append(CareerChampionStats(champion=champion, win_number=win_number))

--- a/altered/tests/test_career_stats_service.py
+++ b/altered/tests/test_career_stats_service.py
@@ -16,14 +16,14 @@ class CareerStatsServiceTests(TestCase):
 
     def test_compute_win_numbers(self):
         service = CareerStatsService()
-        beta_stat = next(s for s in service.result if s.champion == self.champ2)
-        self.assertEqual(beta_stat.win_number, 2)
         alpha_stat = next(s for s in service.result if s.champion == self.champ1)
-        self.assertEqual(alpha_stat.win_number, 0)
+        self.assertEqual(alpha_stat.win_number, 2)
+        beta_stat = next(s for s in service.result if s.champion == self.champ2)
+        self.assertEqual(beta_stat.win_number, 0)
 
     def test_missing_only_filter(self):
         service = CareerStatsService(missing_only=True)
         champs = [stat.champion for stat in service.result]
-        self.assertIn(self.champ1, champs)
+        self.assertIn(self.champ2, champs)
         self.assertIn(self.champ3, champs)
-        self.assertNotIn(self.champ2, champs)
+        self.assertNotIn(self.champ1, champs)


### PR DESCRIPTION
## Summary
- show wins by the deck's champion instead of the opponent's champion
- update Career stats tests accordingly

## Testing
- `pytest altered/tests/test_career_stats_service.py -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68888de4d4e0832992b3d40059d692e2