### PR TITLE
Add navigation header and banner styling to games collection

### DIFF
--- a/games_collection/templates/games_collection/back_to_the_dawn.html
+++ b/games_collection/templates/games_collection/back_to_the_dawn.html
@@ -1,62 +1,65 @@
 {% extends 'games_collection/base.html' %}
 
 {% block content %}
-{% load static %}
+    {% load static %}
 
-<img src="{% static 'games_collection/images/back_to_the_dawn.jpg' %}" alt="{{ game_background }}"
-     class="img-fluid w-100 shadow-sm mb-4" style="height: 200px; object-fit: cover;">
+    <img src="{% static 'games_collection/images/back_to_the_dawn.jpg' %}" alt="{{ game_background }}"
+         class="img-fluid w-100 shadow-sm mb-4" style="height: 200px; object-fit: cover; object-position: 50% 17%;">
 
-<div class="row gy-4">
-  <div class="col-md-6">
-    <div class="card h-100">
-      <div class="card-header bg-primary text-white">Code MailRoom</div>
-      <div class="card-body">
-        <p class="card-text display-6 text-center">2481</p>
-      </div>
+    <div class="row gy-4">
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header bg-primary text-white">Code MailRoom</div>
+                <div class="card-body">
+                    <p class="card-text display-6 text-center">2481</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header bg-success text-white">Accès Infirmerie</div>
+                <ol class="list-group list-group-numbered list-group-flush">
+                    <li class="list-group-item">Get Beaten</li>
+                    <li class="list-group-item">Laxative</li>
+                    <li class="list-group-item">Maladie sur le dossier médicale</li>
+                </ol>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header bg-warning text-dark">Section à explorer</div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">Toit matin</li>
+                    <li class="list-group-item">Derrière les toilettes</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header bg-info text-dark">Objet à récupérer (mission)</div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">Premium Liquor</li>
+                    <li class="list-group-item">Mushroom Powder</li>
+                    <li class="list-group-item">Stonegrass</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="col-md-12">
+            <div class="card h-100">
+                <div class="card-header bg-secondary text-white">Bond à faire</div>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item">Giraffe</li>
+                    <li class="list-group-item">Koala</li>
+                    <li class="list-group-item">Hyena</li>
+                </ul>
+            </div>
+        </div>
     </div>
-  </div>
 
-  <div class="col-md-6">
-    <div class="card h-100">
-      <div class="card-header bg-success text-white">Accès Infirmerie</div>
-      <ol class="list-group list-group-numbered list-group-flush">
-        <li class="list-group-item">Get Beaten</li>
-        <li class="list-group-item">Laxative</li>
-        <li class="list-group-item">Maladie sur le dossier médicale</li>
-      </ol>
-    </div>
-  </div>
-
-  <div class="col-md-6">
-    <div class="card h-100">
-      <div class="card-header bg-warning text-dark">Section à explorer</div>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item">Toit matin</li>
-        <li class="list-group-item">Derrière les toilettes</li>
-      </ul>
-    </div>
-  </div>
-
-  <div class="col-md-6">
-    <div class="card h-100">
-      <div class="card-header bg-info text-dark">Objet à récupérer (mission)</div>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item">Premium Liquor</li>
-        <li class="list-group-item">Mushroom Powder</li>
-        <li class="list-group-item">Stonegrass</li>
-      </ul>
-    </div>
-  </div>
-
-  <div class="col-md-12">
-    <div class="card h-100">
-      <div class="card-header bg-secondary text-white">Bond à faire</div>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item">Giraffe</li>
-        <li class="list-group-item">Koala</li>
-        <li class="list-group-item">Hyena</li>
-      </ul>
-    </div>
-  </div>
-</div>
+    <img src="{% static 'games_collection/images/back_to_the_dawn.jpg' %}" alt="{{ game_background }}"
+         class="img-fluid w-100 shadow-sm mt-4" style="height: 380px; object-fit: cover; object-position: 50% 75%;">
 {% endblock %}

--- a/games_collection/templates/games_collection/back_to_the_dawn.html
+++ b/games_collection/templates/games_collection/back_to_the_dawn.html
@@ -4,7 +4,7 @@
 {% load static %}
 
 <img src="{% static 'games_collection/images/back_to_the_dawn.jpg' %}" alt="{{ game_background }}"
-             class="img-fluid shadow-sm mb-4">
+     class="img-fluid w-100 shadow-sm mb-4" style="height: 200px; object-fit: cover;">
 
 <div class="row gy-4">
   <div class="col-md-6">

--- a/games_collection/templates/games_collection/base.html
+++ b/games_collection/templates/games_collection/base.html
@@ -10,6 +10,14 @@
     {% bootstrap_javascript %}
 </head>
 <body>
+<header class="bg-dark text-white py-3 mb-4">
+    <div class="container">
+        <a href="{% url 'games_collection:home' %}" class="text-white text-decoration-none">
+            <h1 class="m-0">Games Collection</h1>
+        </a>
+    </div>
+</header>
+
 <div class="container py-4">
     {% block content %}{% endblock %}
     {% block scripts %}{% endblock %}


### PR DESCRIPTION
## Summary
- add global header linking back to games collection homepage
- style Back To The Dawn image as top banner

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68937c12aaa48329abe61ffd6ed59c7b