### PR TITLE
Add Greenheart dungeon stats page

### DIFF
--- a/the_bazaar/templates/the_bazaar/greenheart_dungeon.html
+++ b/the_bazaar/templates/the_bazaar/greenheart_dungeon.html
@@ -7,7 +7,7 @@
         <div class="col-md-4 mb-3">
             <div class="card text-center shadow-sm">
                 <div class="card-body">
-                    <h5 class="card-title">Dungeon Usage</h5>
+                    <h5 class="card-title">Dungeon Ratio</h5>
                     <p class="display-6">{{ ratio|floatformat:2 }}%</p>
                     <div class="progress">
                         <div class="progress-bar bg-success" role="progressbar" style="width: {{ ratio }}%" aria-valuenow="{{ ratio }}" aria-valuemin="0" aria-valuemax="100"></div>

--- a/the_bazaar/templates/the_bazaar/greenheart_dungeon.html
+++ b/the_bazaar/templates/the_bazaar/greenheart_dungeon.html
@@ -1,0 +1,37 @@
+{% extends 'the_bazaar/base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Greenheart Dungeon Impact</h2>
+    <div class="row mt-4">
+        <div class="col-md-4 mb-3">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Dungeon Usage</h5>
+                    <p class="display-6">{{ ratio|floatformat:2 }}%</p>
+                    <div class="progress">
+                        <div class="progress-bar bg-success" role="progressbar" style="width: {{ ratio }}%" aria-valuenow="{{ ratio }}" aria-valuemin="0" aria-valuemax="100"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Avg wins with dungeon</h5>
+                    <p class="display-6 text-success">{{ avg_with|floatformat:2 }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4 mb-3">
+            <div class="card text-center shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Avg wins without dungeon</h5>
+                    <p class="display-6 text-danger">{{ avg_without|floatformat:2 }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+

--- a/the_bazaar/templates/the_bazaar/header.html
+++ b/the_bazaar/templates/the_bazaar/header.html
@@ -24,7 +24,11 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'the_bazaar:object_stats' %}">📊 Object stats</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'the_bazaar:greenheart_dungeon' %}">💚 Greenheart Dungeon</a>
+                </li>
             </ul>
         </div>
     </div>
 </nav>
+

--- a/the_bazaar/urls.py
+++ b/the_bazaar/urls.py
@@ -6,6 +6,7 @@ from the_bazaar.views.monster_beater import MonsterBeaterView
 from the_bazaar.views.run_list import RunCreateView, RunUpdateView, RunDeleteView, RunListView
 from the_bazaar.views.object_list import ObjectListView, ObjectCreateView, add_victory
 from the_bazaar.views.object_stats import ObjectStatsView
+from the_bazaar.views.greenheart_dungeon import GreenheartDungeonView
 
 app_name = 'the_bazaar'
 
@@ -22,4 +23,6 @@ urlpatterns = [
     path('object/new/', ObjectCreateView.as_view(), name='object_create'),
     path('object/<int:pk>/add_victory/', add_victory, name='object_add_victory'),
     path('object_stats/', ObjectStatsView.stats, name='object_stats'),
+    path('greenheart_dungeon/', GreenheartDungeonView.stats, name='greenheart_dungeon'),
 ]
+

--- a/the_bazaar/views/greenheart_dungeon.py
+++ b/the_bazaar/views/greenheart_dungeon.py
@@ -7,9 +7,10 @@ from the_bazaar.models import Run
 class GreenheartDungeonView:
     @staticmethod
     def stats(request):
-        total_runs = Run.objects.count()
-        runs_with = Run.objects.filter(greenheart_dungeon=True)
-        runs_without = Run.objects.filter(greenheart_dungeon=False)
+        runs_post_dungeon_patch = Run.objects.filter(season__number__gte=3)
+        total_runs = runs_post_dungeon_patch.count()
+        runs_with = runs_post_dungeon_patch.filter(greenheart_dungeon=True)
+        runs_without = runs_post_dungeon_patch.filter(greenheart_dungeon=False)
 
         if total_runs:
             ratio = runs_with.count() / total_runs * 100

--- a/the_bazaar/views/greenheart_dungeon.py
+++ b/the_bazaar/views/greenheart_dungeon.py
@@ -1,0 +1,31 @@
+from django.db.models import Avg
+from django.shortcuts import render
+
+from the_bazaar.models import Run
+
+
+class GreenheartDungeonView:
+    @staticmethod
+    def stats(request):
+        total_runs = Run.objects.count()
+        runs_with = Run.objects.filter(greenheart_dungeon=True)
+        runs_without = Run.objects.filter(greenheart_dungeon=False)
+
+        if total_runs:
+            ratio = runs_with.count() / total_runs * 100
+        else:
+            ratio = 0
+
+        avg_with = runs_with.aggregate(avg=Avg('win_number'))['avg'] or 0
+        avg_without = runs_without.aggregate(avg=Avg('win_number'))['avg'] or 0
+
+        return render(
+            request,
+            'the_bazaar/greenheart_dungeon.html',
+            {
+                'ratio': ratio,
+                'avg_with': avg_with,
+                'avg_without': avg_without,
+            }
+        )
+


### PR DESCRIPTION
## Summary
- add dedicated view and template to report Greenheart dungeon ratio and average win numbers
- link new stats page in navigation and url configuration

## Testing
- `pytest the_bazaar`


------
https://chatgpt.com/codex/tasks/task_e_689e428af5c883298831ac85d3837555