### PR TITLE
feat: track detailed object victories

### DIFF
--- a/the_bazaar/forms/object.py
+++ b/the_bazaar/forms/object.py
@@ -10,21 +10,24 @@ class ObjectForm(forms.ModelForm):
             'name',
             'character',
             'size',
-            'victory_number',
-            'was_mastered',
+            'bronze_win_number',
+            'silver_win_number',
+            'gold_win_number',
         ]
         widgets = {
             'name': forms.TextInput(attrs={'class': 'form-control'}),
             'character': forms.Select(attrs={'class': 'form-select'}),
             'size': forms.Select(attrs={'class': 'form-select'}),
-            'victory_number': forms.NumberInput(attrs={'class': 'form-control'}),
-            'was_mastered': forms.CheckboxInput(attrs={'class': 'form-check-input'}),
+            'bronze_win_number': forms.NumberInput(attrs={'class': 'form-control'}),
+            'silver_win_number': forms.NumberInput(attrs={'class': 'form-control'}),
+            'gold_win_number': forms.NumberInput(attrs={'class': 'form-control'}),
         }
         labels = {
             'name': 'Nom',
             'character': 'Personnage',
             'size': 'Taille',
-            'victory_number': 'Nombre de victoires',
-            'was_mastered': 'Maîtrisé',
+            'bronze_win_number': 'Bronze wins',
+            'silver_win_number': 'Silver wins',
+            'gold_win_number': 'Gold wins',
         }
 

--- a/the_bazaar/forms/object_stats_filter.py
+++ b/the_bazaar/forms/object_stats_filter.py
@@ -1,6 +1,7 @@
 from django import forms
 
 from the_bazaar.constants.character import Character
+from the_bazaar.constants.result import Result
 
 
 class ObjectStatsFilterForm(forms.Form):
@@ -8,5 +9,16 @@ class ObjectStatsFilterForm(forms.Form):
         choices=[('', 'All Characters')] + Character.choices,
         required=False,
         label='Character',
+        widget=forms.Select(attrs={'class': 'form-select'})
+    )
+    victory_type = forms.ChoiceField(
+        choices=[
+            (Result.GOLD_WIN, 'Gold'),
+            (Result.SILVER_WIN, 'Silver'),
+            (Result.BRONZE_WIN, 'Bronze'),
+        ],
+        required=True,
+        label='Victory type',
+        initial=Result.GOLD_WIN,
         widget=forms.Select(attrs={'class': 'form-select'})
     )

--- a/the_bazaar/migrations/0024_object_win_fields.py
+++ b/the_bazaar/migrations/0024_object_win_fields.py
@@ -1,0 +1,48 @@
+from django.db import migrations, models
+
+from the_bazaar.constants.result import Result
+
+
+def set_best_win(apps, schema_editor):
+    Object = apps.get_model('the_bazaar', 'Object')
+    for obj in Object.objects.all():
+        if obj.was_mastered:
+            obj.best_win = Result.GOLD_WIN
+        else:
+            obj.best_win = None
+        obj.save(update_fields=['best_win'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('the_bazaar', '0023_alter_archetype_character'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='object',
+            old_name='victory_number',
+            new_name='gold_win_number',
+        ),
+        migrations.AddField(
+            model_name='object',
+            name='bronze_win_number',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='object',
+            name='silver_win_number',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='object',
+            name='best_win',
+            field=models.CharField(choices=Result.choices, max_length=10, null=True, blank=True),
+        ),
+        migrations.RunPython(set_best_win, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='object',
+            name='was_mastered',
+        ),
+    ]

--- a/the_bazaar/migrations/0025_object_win_fields.py
+++ b/the_bazaar/migrations/0025_object_win_fields.py
@@ -16,7 +16,7 @@ def set_best_win(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('the_bazaar', '0023_alter_archetype_character'),
+        ('the_bazaar', '0024_fight'),
     ]
 
     operations = [

--- a/the_bazaar/models/object.py
+++ b/the_bazaar/models/object.py
@@ -3,6 +3,7 @@ from django.db import models
 
 from the_bazaar.constants.character import Character
 from the_bazaar.constants.item_size import ItemSize
+from the_bazaar.constants.result import Result
 
 
 class Object(models.Model):
@@ -13,8 +14,15 @@ class Object(models.Model):
         choices=ItemSize.choices,
         default=ItemSize.SMALL,
     )
-    was_mastered = models.BooleanField(default=False)
-    victory_number = models.IntegerField(default=0)
+    best_win = models.CharField(
+        max_length=10,
+        choices=Result.choices,
+        null=True,
+        blank=True,
+    )
+    bronze_win_number = models.IntegerField(default=0)
+    silver_win_number = models.IntegerField(default=0)
+    gold_win_number = models.IntegerField(default=0)
 
     def __str__(self):
         return self.name
@@ -26,8 +34,10 @@ class ObjectAdmin(admin.ModelAdmin):
         'name',
         'character',
         'size',
-        'victory_number',
-        'was_mastered',
+        'gold_win_number',
+        'silver_win_number',
+        'bronze_win_number',
+        'best_win',
     )
-    list_filter = ('character', 'size', 'was_mastered')
+    list_filter = ('character', 'size', 'best_win')
     ordering = ('name',)

--- a/the_bazaar/services/aggregate_object_stats.py
+++ b/the_bazaar/services/aggregate_object_stats.py
@@ -1,11 +1,13 @@
 from the_bazaar.constants.character import Character
+from the_bazaar.constants.result import Result
 from the_bazaar.models import Object
 from the_bazaar.value_objects.aggregate_object_stats import AggregateObjectStatsResult
 
 
 class AggregateObjectStatsService:
-    def __init__(self, character: str | None = None):
+    def __init__(self, character: str | None = None, victory_type: str = Result.GOLD_WIN):
         self.character = character
+        self.victory_type = victory_type
         self.sanitize()
         label = Character(character).label if character else "All"
         self.result = AggregateObjectStatsResult(character=label)
@@ -15,6 +17,8 @@ class AggregateObjectStatsService:
     def sanitize(self):
         if self.character is not None and self.character not in Character.values:
             raise ValueError(f"{self.character} is not a valid character.")
+        if self.victory_type not in Result.values:
+            raise ValueError(f"{self.victory_type} is not a valid result.")
 
     def get_objects(self):
         if self.character:
@@ -23,18 +27,23 @@ class AggregateObjectStatsService:
 
     def compute(self):
         self.compute_total_objects()
-        self.compute_mastered_objects()
-        self.compute_mastered_ratio()
+        self.compute_winning_objects()
+        self.compute_winning_ratio()
 
     def compute_total_objects(self):
         self.result.total_objects = self.objects.count()
 
-    def compute_mastered_objects(self):
-        self.result.mastered_objects = self.objects.filter(was_mastered=True).count()
+    def compute_winning_objects(self):
+        allowed = [Result.GOLD_WIN]
+        if self.victory_type in (Result.SILVER_WIN, Result.BRONZE_WIN):
+            allowed.append(Result.SILVER_WIN)
+        if self.victory_type == Result.BRONZE_WIN:
+            allowed.append(Result.BRONZE_WIN)
+        self.result.winning_objects = self.objects.filter(best_win__in=allowed).count()
 
-    def compute_mastered_ratio(self):
+    def compute_winning_ratio(self):
         if self.result.total_objects == 0:
-            self.result.mastered_ratio = 0.0
+            self.result.winning_ratio = 0.0
         else:
-            ratio = self.result.mastered_objects / self.result.total_objects * 100
-            self.result.mastered_ratio = round(ratio, 2)
+            ratio = self.result.winning_objects / self.result.total_objects * 100
+            self.result.winning_ratio = round(ratio, 2)

--- a/the_bazaar/templates/the_bazaar/object_list.html
+++ b/the_bazaar/templates/the_bazaar/object_list.html
@@ -14,8 +14,8 @@
                 {{ filter.form.character|add_class:"form-select form-select-sm" }}
             </div>
             <div class="col-auto">
-                <label for="id_was_mastered" class="form-label">Maîtrisé</label>
-                {{ filter.form.was_mastered|add_class:"form-select form-select-sm" }}
+                <label for="id_best_win" class="form-label">Best Win</label>
+                {{ filter.form.best_win|add_class:"form-select form-select-sm" }}
             </div>
             <div class="col-auto">
                 <button class="btn btn-sm btn-primary" type="submit">Filtrer</button>
@@ -29,22 +29,47 @@
                 <th>Nom</th>
                 <th>Character</th>
                 <th>Taille</th>
-                <th>Maîtrisé</th>
-                <th>Victoires</th>
+                <th>Bronze</th>
+                <th>Silver</th>
+                <th>Gold</th>
                 <th></th>
             </tr>
             </thead>
             <tbody>
             {% for obj in objects %}
-                <tr class="{% if obj.was_mastered %}table-success{% endif %}">
+                <tr class="{% if obj.best_win == 'GOLD_WIN' %}table-success{% elif obj.best_win == 'SILVER_WIN' %}table-info{% elif obj.best_win == 'BRONZE_WIN' %}table-warning{% endif %}">
                     <td>{{ obj.name }}</td>
                     <td>{{ obj.get_character_display }}</td>
                     <td>{{ obj.get_size_display }}</td>
-                    <td>{% if obj.was_mastered %}✅{% else %}❌{% endif %}</td>
-                    <td>{{ obj.victory_number }}</td>
+                    <td>{{ obj.bronze_win_number }}</td>
+                    <td>{{ obj.silver_win_number }}</td>
+                    <td>{{ obj.gold_win_number }}</td>
                     <td>
-                        <a href="{% url 'the_bazaar:object_add_victory' obj.id %}"
-                           class="btn btn-sm btn-outline-secondary">Add a victory</a>
+                        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#addVictoryModal{{ obj.id }}">Add a victory</button>
+                        <div class="modal fade" id="addVictoryModal{{ obj.id }}" tabindex="-1" aria-labelledby="addVictoryLabel{{ obj.id }}" aria-hidden="true">
+                          <div class="modal-dialog">
+                            <div class="modal-content">
+                              <form method="post" action="{% url 'the_bazaar:object_add_victory' obj.id %}">
+                                {% csrf_token %}
+                                <div class="modal-header">
+                                  <h5 class="modal-title" id="addVictoryLabel{{ obj.id }}">Add a victory</h5>
+                                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                  <label for="victoryType{{ obj.id }}" class="form-label">Victory type</label>
+                                  <select class="form-select" id="victoryType{{ obj.id }}" name="victory_type">
+                                    <option value="BRONZE_WIN">Bronze</option>
+                                    <option value="SILVER_WIN">Silver</option>
+                                    <option value="GOLD_WIN" selected>Gold</option>
+                                  </select>
+                                </div>
+                                <div class="modal-footer">
+                                  <button type="submit" class="btn btn-primary">Save</button>
+                                </div>
+                              </form>
+                            </div>
+                          </div>
+                        </div>
                     </td>
                 </tr>
             {% empty %}

--- a/the_bazaar/templates/the_bazaar/object_stats.html
+++ b/the_bazaar/templates/the_bazaar/object_stats.html
@@ -10,6 +10,10 @@
                 {{ form.character|add_class:"form-select" }}
             </div>
             <div class="col-auto">
+                {{ form.victory_type.label_tag }}
+                {{ form.victory_type|add_class:"form-select" }}
+            </div>
+            <div class="col-auto">
                 <button type="submit" class="btn btn-primary">Filter</button>
             </div>
         </form>
@@ -20,12 +24,12 @@
                 <td>{{ stats.total_objects }}</td>
             </tr>
             <tr>
-                <th scope="row">Mastered Objects</th>
-                <td>{{ stats.mastered_objects }}</td>
+                <th scope="row">Winning Objects</th>
+                <td>{{ stats.winning_objects }}</td>
             </tr>
             <tr>
-                <th scope="row">Mastery Ratio</th>
-                <td>{{ stats.mastered_ratio }}%</td>
+                <th scope="row">Win Ratio</th>
+                <td>{{ stats.winning_ratio }}%</td>
             </tr>
             </tbody>
         </table>

--- a/the_bazaar/value_objects/aggregate_object_stats.py
+++ b/the_bazaar/value_objects/aggregate_object_stats.py
@@ -5,5 +5,5 @@ import dataclasses
 class AggregateObjectStatsResult:
     character: str
     total_objects: int = 0
-    mastered_objects: int = 0
-    mastered_ratio: float = 0.0
+    winning_objects: int = 0
+    winning_ratio: float = 0.0

--- a/the_bazaar/views/object_stats.py
+++ b/the_bazaar/views/object_stats.py
@@ -2,16 +2,19 @@ from django.shortcuts import render
 
 from the_bazaar.forms.object_stats_filter import ObjectStatsFilterForm
 from the_bazaar.services.aggregate_object_stats import AggregateObjectStatsService
+from the_bazaar.constants.result import Result
 
 
 class ObjectStatsView:
     @staticmethod
     def stats(request):
-        form = ObjectStatsFilterForm(request.GET)
+        form = ObjectStatsFilterForm(request.GET or None)
         character = None
+        victory_type = Result.GOLD_WIN
         if form.is_valid():
             character = form.cleaned_data.get('character') or None
-        service = AggregateObjectStatsService(character)
+            victory_type = form.cleaned_data.get('victory_type')
+        service = AggregateObjectStatsService(character, victory_type)
         return render(
             request,
             'the_bazaar/object_stats.html',


### PR DESCRIPTION
## Summary
- replace object mastery flag with detailed win tracking and best win enum
- allow filtering object stats by victory type and display win counts
- add modal to record bronze/silver/gold wins per object

## Testing
- `pytest` *(fails: No module named 'django')*
- `pip install django django-filter django-bootstrap5` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_689eeb5fd2548329b60d3f4da1e34a59