### PR TITLE
Add meta stats page and remove default fight form

### DIFF
--- a/the_bazaar/services/fight_character_repartition.py
+++ b/the_bazaar/services/fight_character_repartition.py
@@ -1,0 +1,20 @@
+from collections import Counter
+
+import plotly.express as px
+
+from the_bazaar.models import Fight
+
+
+class FightCharacterRepartitionService:
+    """Generate a pie chart of fights per opponent character."""
+
+    @classmethod
+    def generate(cls):
+        fights = Fight.objects.all()
+        counts = Counter(fight.opponent_character for fight in fights)
+        data = {
+            'Character': list(counts.keys()),
+            'Count': list(counts.values()),
+        }
+        fig = px.pie(data, names='Character', values='Count')
+        return fig.to_html(full_html=False, include_plotlyjs='cdn')

--- a/the_bazaar/services/fight_character_timeseries.py
+++ b/the_bazaar/services/fight_character_timeseries.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import plotly.express as px
+
+from the_bazaar.constants.character import Character
+from the_bazaar.models import Fight
+
+
+class FightCharacterTimeseriesService:
+    """Generate a line chart of fights per opponent character per day."""
+
+    @classmethod
+    def generate(cls):
+        fights = Fight.objects.all()
+        records = [
+            {
+                'day': fight.day_number,
+                'character': fight.opponent_character,
+            }
+            for fight in fights
+        ]
+
+        if not records:
+            df = pd.DataFrame({'day': [], 'character': [], 'count': []})
+        else:
+            df = pd.DataFrame(records)
+            day_range = range(df['day'].min(), df['day'].max() + 1)
+            idx = pd.MultiIndex.from_product([day_range, Character.values], names=['day', 'character'])
+            df = (
+                df.groupby(['day', 'character'])
+                  .size()
+                  .reindex(idx, fill_value=0)
+                  .reset_index(name='count')
+            )
+        fig = px.line(df, x='day', y='count', color='character')
+        return fig.to_html(full_html=False, include_plotlyjs='cdn')

--- a/the_bazaar/templates/the_bazaar/header.html
+++ b/the_bazaar/templates/the_bazaar/header.html
@@ -16,6 +16,9 @@
                     <a class="nav-link" href="{% url 'the_bazaar:archetype_stats' %}">🃏 Archetype stats</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="{% url 'the_bazaar:meta' %}">📈 Meta</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="{% url 'the_bazaar:monster_beater_home' %}">🦖 Monster Analysis</a>
                 </li>
                 <li class="nav-item">

--- a/the_bazaar/templates/the_bazaar/meta.html
+++ b/the_bazaar/templates/the_bazaar/meta.html
@@ -8,7 +8,7 @@
             <div class="card shadow-sm h-100">
                 <div class="card-body d-flex flex-column justify-content-center align-items-center">
                     <h5 class="card-title">Opponent Character Repartition</h5>
-                    {{ pie_chart|safe }}
+                    {{ character_total_repartition|safe }}
                 </div>
             </div>
         </div>
@@ -16,7 +16,7 @@
             <div class="card shadow-sm h-100">
                 <div class="card-body">
                     <h5 class="card-title">Fights per Day</h5>
-                    {{ line_chart|safe }}
+                    {{ daily_repartition|safe }}
                 </div>
             </div>
         </div>

--- a/the_bazaar/templates/the_bazaar/meta.html
+++ b/the_bazaar/templates/the_bazaar/meta.html
@@ -1,0 +1,25 @@
+{% extends 'the_bazaar/base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Meta</h2>
+    <div class="row">
+        <div class="col-md-6 mb-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-body d-flex flex-column justify-content-center align-items-center">
+                    <h5 class="card-title">Opponent Character Repartition</h5>
+                    {{ pie_chart|safe }}
+                </div>
+            </div>
+        </div>
+        <div class="col-md-12 mb-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Fights per Day</h5>
+                    {{ line_chart|safe }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/the_bazaar/urls.py
+++ b/the_bazaar/urls.py
@@ -7,6 +7,7 @@ from the_bazaar.views.run_list import RunCreateView, RunUpdateView, RunDeleteVie
 from the_bazaar.views.object_list import ObjectListView, ObjectCreateView, add_victory
 from the_bazaar.views.object_stats import ObjectStatsView
 from the_bazaar.views.greenheart_dungeon import GreenheartDungeonView
+from the_bazaar.views.meta import MetaView
 
 app_name = 'the_bazaar'
 
@@ -24,5 +25,6 @@ urlpatterns = [
     path('object/<int:pk>/add_victory/', add_victory, name='object_add_victory'),
     path('object_stats/', ObjectStatsView.stats, name='object_stats'),
     path('greenheart_dungeon/', GreenheartDungeonView.stats, name='greenheart_dungeon'),
+    path('meta/', MetaView.stats, name='meta'),
 ]
 

--- a/the_bazaar/views/meta.py
+++ b/the_bazaar/views/meta.py
@@ -7,13 +7,13 @@ from the_bazaar.services.fight_character_timeseries import FightCharacterTimeser
 class MetaView:
     @staticmethod
     def stats(request):
-        pie_chart = FightCharacterRepartitionService.generate()
-        line_chart = FightCharacterTimeseriesService.generate()
+        character_total_repartition = FightCharacterRepartitionService.generate()
+        daily_repartition = FightCharacterTimeseriesService.generate()
         return render(
             request,
             'the_bazaar/meta.html',
             {
-                'pie_chart': pie_chart,
-                'line_chart': line_chart,
+                'character_total_repartition': character_total_repartition,
+                'daily_repartition': daily_repartition,
             }
         )

--- a/the_bazaar/views/meta.py
+++ b/the_bazaar/views/meta.py
@@ -1,0 +1,19 @@
+from django.shortcuts import render
+
+from the_bazaar.services.fight_character_repartition import FightCharacterRepartitionService
+from the_bazaar.services.fight_character_timeseries import FightCharacterTimeseriesService
+
+
+class MetaView:
+    @staticmethod
+    def stats(request):
+        pie_chart = FightCharacterRepartitionService.generate()
+        line_chart = FightCharacterTimeseriesService.generate()
+        return render(
+            request,
+            'the_bazaar/meta.html',
+            {
+                'pie_chart': pie_chart,
+                'line_chart': line_chart,
+            }
+        )

--- a/the_bazaar/views/run_list.py
+++ b/the_bazaar/views/run_list.py
@@ -27,7 +27,8 @@ class RunListView(FilterView):
     filterset_class = RunFilter
     ordering = ['-created_at']
 
-FightFormSet = inlineformset_factory(Run, Fight, form=FightForm, extra=1, can_delete=True)
+# Do not display a fight form by default when creating a run
+FightFormSet = inlineformset_factory(Run, Fight, form=FightForm, extra=0, can_delete=True)
 
 class RunCreateView(CreateView):
     model = Run

--- a/the_bazaar/views/run_list.py
+++ b/the_bazaar/views/run_list.py
@@ -27,7 +27,6 @@ class RunListView(FilterView):
     filterset_class = RunFilter
     ordering = ['-created_at']
 
-# Do not display a fight form by default when creating a run
 FightFormSet = inlineformset_factory(Run, Fight, form=FightForm, extra=0, can_delete=True)
 
 class RunCreateView(CreateView):


### PR DESCRIPTION
## Summary
- Stop adding a default fight form when creating a new run
- Add a Meta stats page with opponent character pie chart and daily fight line chart
- Plot fights per day using each fight's `day_number` instead of the run's creation date

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django pytest` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a03dbab540832987611af0071b41cf