### PR TITLE
Display Runeterra Objectives and Ideas via documents app

### DIFF
--- a/runeterra/templates/runeterra/document.html
+++ b/runeterra/templates/runeterra/document.html
@@ -1,0 +1,8 @@
+{% extends 'runeterra/base.html' %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ title }}</h1>
+    <div class="mt-4">{{ content_html }}</div>
+{% endblock %}

--- a/runeterra/templates/runeterra/header.html
+++ b/runeterra/templates/runeterra/header.html
@@ -14,6 +14,12 @@
             <li class="nav-item">
                 <a class="nav-link" href="{% url 'runeterra:region_stats' %}">Region Stats</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'runeterra:objectives' %}">Objectives</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'runeterra:ideas' %}">Ideas</a>
+            </li>
         </ul>
     </div>
 </nav>

--- a/runeterra/urls.py
+++ b/runeterra/urls.py
@@ -6,6 +6,8 @@ app_name = "runeterra"
 
 urlpatterns = [
     path("", views.random_picker, name="random_picker"),
+    path("objectives/", views.objectives, name="objectives"),
+    path("ideas/", views.ideas, name="ideas"),
     path("stats/", views.region_stats, name="region_stats"),
     path("champions/", views.champion_list, name="champion_list"),
     path("champions/new/", views.ChampionCreateView.as_view(), name="champion_create"),

--- a/runeterra/views/__init__.py
+++ b/runeterra/views/__init__.py
@@ -1,6 +1,7 @@
 from .random import random_picker
 from .champion import champion_list, ChampionCreateView, ChampionUpdateView
 from .stats import region_stats
+from .documents import objectives, ideas
 
 __all__ = [
     "random_picker",
@@ -8,4 +9,6 @@ __all__ = [
     "ChampionCreateView",
     "ChampionUpdateView",
     "region_stats",
+    "objectives",
+    "ideas",
 ]

--- a/runeterra/views/documents.py
+++ b/runeterra/views/documents.py
@@ -1,0 +1,28 @@
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+import markdown
+
+from documents.models import Document
+from documents.constants.directories import Directories
+
+
+def _render_document(request, title: str):
+    document, _ = Document.objects.get_or_create(
+        title=title,
+        directory=Directories.RUNETERRA,
+        defaults={"content": ""},
+    )
+    content_html = mark_safe(markdown.markdown(document.content))
+    return render(
+        request,
+        "runeterra/document.html",
+        {"title": title, "content_html": content_html},
+    )
+
+
+def objectives(request):
+    return _render_document(request, "Objectives")
+
+
+def ideas(request):
+    return _render_document(request, "Ideas")


### PR DESCRIPTION
## Summary
- render Objectives and Ideas pages from documents app
- add generic document template and navigation link for Ideas
- remove unused placeholder Objectives file

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django pytest-django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cad93de88329a6a0b13aeb62c30f