### PR TITLE
Add document pages for Agathe and Agather directory

### DIFF
--- a/agathe/templates/agathe/document.html
+++ b/agathe/templates/agathe/document.html
@@ -1,0 +1,10 @@
+{% extends 'agathe/base.html' %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+    <h1>{{ title }}</h1>
+    <a class="btn btn-secondary btn-sm" href="{% url 'documents:document_edit' document.pk %}">Edit</a>
+    <div class="mt-4">{{ content_html }}</div>
+{% endblock %}
+

--- a/agathe/templates/agathe/header.html
+++ b/agathe/templates/agathe/header.html
@@ -12,6 +12,12 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{% url 'agathe:diaper_change' %}">Couche</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'agathe:question_to_ask' %}">Question à poser</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'agathe:next_evolution_milestone' %}">Next évolution milestone</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/agathe/urls.py
+++ b/agathe/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from agathe.views.home import HomeController
 from agathe.views.pit_stop import PitStopController
 from agathe.views.diaper_change import DiaperChangeController
+from agathe.views.documents import DocumentController
 
 app_name = "agathe"
 
@@ -11,4 +12,10 @@ urlpatterns = [
     path("pit_stop/", PitStopController.pit_stop, name="pit_stop"),
     path("pit_stop/<int:pk>/finish/", PitStopController.finish, name="pit_stop_finish"),
     path("diaper_change/", DiaperChangeController.diaper_change, name="diaper_change"),
+    path("question/", DocumentController.question_to_ask, name="question_to_ask"),
+    path(
+        "next_evolution_milestone/",
+        DocumentController.next_evolution_milestone,
+        name="next_evolution_milestone",
+    ),
 ]

--- a/agathe/views/documents.py
+++ b/agathe/views/documents.py
@@ -1,0 +1,31 @@
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+import markdown
+
+from documents.models import Document
+from documents.constants.directories import Directories
+
+
+class DocumentController:
+    @staticmethod
+    def _render_document(request, title: str):
+        document, _ = Document.objects.get_or_create(
+            title=title,
+            directory=Directories.AGATHER,
+            defaults={"content": ""},
+        )
+        content_html = mark_safe(markdown.markdown(document.content))
+        return render(
+            request,
+            "agathe/document.html",
+            {"title": title, "content_html": content_html, "document": document},
+        )
+
+    @staticmethod
+    def question_to_ask(request):
+        return DocumentController._render_document(request, "Question à poser")
+
+    @staticmethod
+    def next_evolution_milestone(request):
+        return DocumentController._render_document(request, "Next évolution milestone")
+

--- a/documents/constants/directories.py
+++ b/documents/constants/directories.py
@@ -7,3 +7,4 @@ class Directories(models.TextChoices):
     ALTERED = "altered", "Altered"
     RUNETERRA = "runeterra", "Runeterra"
     BAZAAR = "bazaar", "The Bazaar"
+    AGATHER = "agather", "Agather"


### PR DESCRIPTION
## Summary
- add Agather directory option for documents
- add Question à poser and Next évolution milestone pages in Agathe backed by documents app
- link new pages in Agathe navigation with edit buttons

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68af14d4c9488329adedaf8b3c0115d5