### PR TITLE
Add guard for PitStop duration and finish button on home page

### DIFF
--- a/agathe/apps.py
+++ b/agathe/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AgatheConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'agathe'
+
+    def ready(self):
+        import agathe.signals  # noqa: F401

--- a/agathe/signals.py
+++ b/agathe/signals.py
@@ -1,0 +1,13 @@
+from datetime import timedelta
+
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from .models import PitStop
+
+
+@receiver(pre_save, sender=PitStop)
+def limit_pit_stop_duration(sender, instance, **kwargs):
+    if instance.start_date and instance.end_date:
+        if instance.end_date - instance.start_date > timedelta(hours=1):
+            instance.end_date = instance.start_date + timedelta(minutes=15)

--- a/agathe/templates/agathe/home.html
+++ b/agathe/templates/agathe/home.html
@@ -10,6 +10,12 @@
                 <li>{{ last_pit_stop.start_date|date:"H:i" }}</li>
                 <li>Sein <strong>{{ last_pit_stop.get_side_display }}</strong></li>
             </ul>
+            {% if last_pit_stop.ongoing %}
+            <form method="post" action="{% url 'agathe:pit_stop_finish_current' %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-secondary mt-2">Fin du pit stop en cours</button>
+            </form>
+            {% endif %}
         {% else %}
             <p>Aucun pit stop enregistré.</p>
         {% endif %}

--- a/agathe/urls.py
+++ b/agathe/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
     path("", HomeController.home, name="home"),
     path("pit_stop/", PitStopController.pit_stop, name="pit_stop"),
     path("pit_stop/<int:pk>/finish/", PitStopController.finish, name="pit_stop_finish"),
+    path(
+        "pit_stop/finish_current/",
+        PitStopController.finish_current,
+        name="pit_stop_finish_current",
+    ),
     path("diaper_change/", DiaperChangeController.diaper_change, name="diaper_change"),
     path("vitamin_intake/", VitaminIntakeController.create, name="vitamin_intake"),
     path("bath/", BathController.create, name="bath"),

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -27,3 +27,16 @@ class PitStopController:
             pit_stop.end_date = timezone.now()
             pit_stop.save()
         return redirect("agathe:pit_stop")
+
+    @staticmethod
+    def finish_current(request):
+        if request.method == "POST":
+            pit_stop = (
+                PitStop.objects.filter(end_date__isnull=True)
+                .order_by("-start_date")
+                .first()
+            )
+            if pit_stop:
+                pit_stop.end_date = timezone.now()
+                pit_stop.save()
+        return redirect("agathe:home")


### PR DESCRIPTION
## Summary
- Limit PitStop duration before saving to 15 minutes if over one hour
- Add button on home page to end current PitStop
- Wire up signal loading and route for finishing current PitStop

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b15bed69d483298a620f46e488ee07