### PR TITLE
Agathe: start new pit stop from homepage when last ended

### DIFF
--- a/agathe/templates/agathe/home.html
+++ b/agathe/templates/agathe/home.html
@@ -20,6 +20,13 @@
                         <button type="submit" class="btn btn-secondary">Finir actuel</button>
                     </form>
                 </div>
+                {% else %}
+                <div>
+                    <form method="post" action="{% url 'agathe:pit_stop_start' %}">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-primary">Nouveau pit stop</button>
+                    </form>
+                </div>
                 {% endif %}
             </div>
         {% else %}

--- a/agathe/urls.py
+++ b/agathe/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
         PitStopController.finish_current,
         name="pit_stop_finish_current",
     ),
+    path("pit_stop/start/", PitStopController.start, name="pit_stop_start"),
     path("diaper_change/", DiaperChangeController.diaper_change, name="diaper_change"),
     path("vitamin_intake/", VitaminIntakeController.create, name="vitamin_intake"),
     path("bath/", BathController.create, name="bath"),

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -40,3 +40,14 @@ class PitStopController:
                 pit_stop.end_date = timezone.now()
                 pit_stop.save()
         return redirect("agathe:home")
+
+    @staticmethod
+    def start(request):
+        if request.method == "POST":
+            last = PitStop.objects.order_by("-start_date").first()
+            if last and last.side == PitStop.Side.LEFT:
+                side = PitStop.Side.RIGHT
+            else:
+                side = PitStop.Side.LEFT
+            PitStop.objects.create(start_date=timezone.now(), side=side)
+        return redirect("agathe:home")


### PR DESCRIPTION
## Summary
- add view and URL to start a new pit stop with opposite side and current time
- show button on home page to launch new pit stop when previous one finished

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django pytest-django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68b16a00382c8329a25089d905e6a5d5