### PR TITLE
Add pit stop stats page with daily line chart

### DIFF
--- a/agathe/services/pit_stop_timeseries.py
+++ b/agathe/services/pit_stop_timeseries.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import plotly.express as px
+from datetime import date
+
+from agathe.models import PitStop
+
+
+class PitStopTimeseriesService:
+    """Generate a line chart of pit stops per day."""
+
+    START_DATE = date(2024, 8, 28)
+
+    @classmethod
+    def generate(cls):
+        pit_stops = PitStop.objects.filter(start_date__date__gte=cls.START_DATE)
+        records = [{"day": ps.start_date.date()} for ps in pit_stops]
+        if not records:
+            df = pd.DataFrame({"day": [], "count": []})
+        else:
+            df = pd.DataFrame(records)
+            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            df = (
+                df.groupby("day")
+                .size()
+                .reindex(day_range, fill_value=0)
+                .reset_index(name="count")
+            )
+        fig = px.line(df, x="day", y="count")
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")

--- a/agathe/templates/agathe/header.html
+++ b/agathe/templates/agathe/header.html
@@ -10,6 +10,9 @@
                     <a class="nav-link" href="{% url 'agathe:pit_stop' %}">Pit Stop</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="{% url 'agathe:pit_stop_stats' %}">Stats</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="{% url 'agathe:diaper_change' %}">Couche</a>
                 </li>
                 <li class="nav-item">

--- a/agathe/templates/agathe/pit_stop_stats.html
+++ b/agathe/templates/agathe/pit_stop_stats.html
@@ -1,0 +1,9 @@
+{% extends 'agathe/base.html' %}
+
+{% block content %}
+<h2 class="mb-4">Statistiques Pit Stop</h2>
+<div class="card p-4 shadow-sm">
+    <h5 class="card-title">Pit stops par jour</h5>
+    {{ pit_stops_per_day|safe }}
+</div>
+{% endblock %}

--- a/agathe/urls.py
+++ b/agathe/urls.py
@@ -13,6 +13,7 @@ app_name = "agathe"
 urlpatterns = [
     path("", HomeController.home, name="home"),
     path("pit_stop/", PitStopController.pit_stop, name="pit_stop"),
+    path("pit_stop/stats/", PitStopController.stats, name="pit_stop_stats"),
     path("pit_stop/<int:pk>/finish/", PitStopController.finish, name="pit_stop_finish"),
     path(
         "pit_stop/finish_current/",

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 
 from agathe.forms.pit_stop import PitStopForm
 from agathe.models import PitStop
+from agathe.services.pit_stop_timeseries import PitStopTimeseriesService
 
 
 class PitStopController:
@@ -18,7 +19,9 @@ class PitStopController:
         else:
             form = PitStopForm()
         pit_stops = PitStop.objects.all().order_by("-start_date")[:5]
-        return render(request, "agathe/pit_stop.html", {"form": form, "pit_stops": pit_stops})
+        return render(
+            request, "agathe/pit_stop.html", {"form": form, "pit_stops": pit_stops}
+        )
 
     @staticmethod
     def finish(request, pk):
@@ -40,6 +43,15 @@ class PitStopController:
                 pit_stop.end_date = timezone.now()
                 pit_stop.save()
         return redirect("agathe:home")
+
+    @staticmethod
+    def stats(request):
+        pit_stops_per_day = PitStopTimeseriesService.generate()
+        return render(
+            request,
+            "agathe/pit_stop_stats.html",
+            {"pit_stops_per_day": pit_stops_per_day},
+        )
 
     @staticmethod
     def start(request):


### PR DESCRIPTION
## Summary
- add service to compute pit stop counts per day and render line chart starting Aug 28
- expose new stats view and template with navigation link

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b762a3848329b8fa253742748fce