### PR TITLE
feat: add pit stop duration and interval graphs

### DIFF
--- a/agathe/constants/agathe.py
+++ b/agathe/constants/agathe.py
@@ -1,3 +1,7 @@
+from datetime import date
+
+
 class AgatheConstant:
     BIRTHDATE = "2025-08-23"
     FOOD_INTERVAL = 4
+    GRAPH_START_DATE = date(2025, 8, 28)

--- a/agathe/services/graph/pit_stop_timeseries.py
+++ b/agathe/services/graph/pit_stop_timeseries.py
@@ -2,23 +2,22 @@ import pandas as pd
 import plotly.express as px
 from datetime import date
 
+from agathe.constants.agathe import AgatheConstant
 from agathe.models import PitStop
 
 
 class PitStopTimeseriesChart:
     """Generate a line chart of pit stops per day."""
 
-    START_DATE = date(2025, 8, 28)
-
-    @classmethod
-    def generate(cls):
-        pit_stops = PitStop.objects.filter(start_date__date__gte=cls.START_DATE)
+    @staticmethod
+    def generate():
+        pit_stops = PitStop.objects.filter(start_date__date__gte=AgatheConstant.GRAPH_START_DATE)
         records = [{"day": ps.start_date.date()} for ps in pit_stops]
         if not records:
             df = pd.DataFrame({"day": [], "count": []})
         else:
             df = pd.DataFrame(records)
-            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            day_range = pd.date_range(start=AgatheConstant.GRAPH_START_DATE, end=df["day"].max())
             df = (
                 df.groupby("day")
                 .size()
@@ -30,13 +29,13 @@ class PitStopTimeseriesChart:
         return fig.to_html(full_html=False, include_plotlyjs="cdn")
 
 
-class PitStopDurationTimeseriesChart(PitStopTimeseriesChart):
+class PitStopDurationTimeseriesChart():
     """Generate a line chart of average pit stop duration per day."""
 
-    @classmethod
-    def generate(cls):
+    @staticmethod
+    def generate():
         pit_stops = PitStop.objects.filter(
-            start_date__date__gte=cls.START_DATE, end_date__isnull=False
+            start_date__date__gte=AgatheConstant.GRAPH_START_DATE, end_date__isnull=False
         )
         records = [
             {"day": ps.start_date.date(), "duration": ps.duration}
@@ -46,7 +45,7 @@ class PitStopDurationTimeseriesChart(PitStopTimeseriesChart):
             df = pd.DataFrame({"day": [], "avg_duration": []})
         else:
             df = pd.DataFrame(records)
-            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            day_range = pd.date_range(start=AgatheConstant.GRAPH_START_DATE, end=df["day"].max())
             df = (
                 df.groupby("day")["duration"]
                 .mean()
@@ -58,12 +57,12 @@ class PitStopDurationTimeseriesChart(PitStopTimeseriesChart):
         return fig.to_html(full_html=False, include_plotlyjs="cdn")
 
 
-class PitStopIntervalTimeseriesChart(PitStopTimeseriesChart):
+class PitStopIntervalTimeseriesChart():
     """Generate a line chart of average time between pit stops per day."""
 
-    @classmethod
-    def generate(cls):
-        pit_stops = PitStop.objects.filter(start_date__date__gte=cls.START_DATE).order_by(
+    @staticmethod
+    def generate():
+        pit_stops = PitStop.objects.filter(start_date__date__gte=AgatheConstant.GRAPH_START_DATE).order_by(
             "start_date"
         )
         records = []
@@ -72,7 +71,7 @@ class PitStopIntervalTimeseriesChart(PitStopTimeseriesChart):
             if previous_end:
                 delta = ps.start_date - previous_end
                 records.append(
-                    {"day": ps.start_date.date(), "interval": delta.total_seconds() / 60}
+                    {"day": ps.start_date.date(), "interval": delta.total_seconds() / (60*60)}
                 )
             if ps.end_date:
                 previous_end = ps.end_date
@@ -80,7 +79,7 @@ class PitStopIntervalTimeseriesChart(PitStopTimeseriesChart):
             df = pd.DataFrame({"day": [], "avg_interval": []})
         else:
             df = pd.DataFrame(records)
-            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            day_range = pd.date_range(start=AgatheConstant.GRAPH_START_DATE, end=df["day"].max())
             df = (
                 df.groupby("day")["interval"]
                 .mean()

--- a/agathe/services/graph/pit_stop_timeseries.py
+++ b/agathe/services/graph/pit_stop_timeseries.py
@@ -28,3 +28,65 @@ class PitStopTimeseriesChart:
             df = df.rename(columns={"index": "day"})
         fig = px.line(df, x="day", y="count")
         return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+class PitStopDurationTimeseriesChart(PitStopTimeseriesChart):
+    """Generate a line chart of average pit stop duration per day."""
+
+    @classmethod
+    def generate(cls):
+        pit_stops = PitStop.objects.filter(
+            start_date__date__gte=cls.START_DATE, end_date__isnull=False
+        )
+        records = [
+            {"day": ps.start_date.date(), "duration": ps.duration}
+            for ps in pit_stops
+        ]
+        if not records:
+            df = pd.DataFrame({"day": [], "avg_duration": []})
+        else:
+            df = pd.DataFrame(records)
+            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            df = (
+                df.groupby("day")["duration"]
+                .mean()
+                .reindex(day_range, fill_value=0)
+                .reset_index()
+            )
+            df = df.rename(columns={"index": "day", "duration": "avg_duration"})
+        fig = px.line(df, x="day", y="avg_duration")
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+class PitStopIntervalTimeseriesChart(PitStopTimeseriesChart):
+    """Generate a line chart of average time between pit stops per day."""
+
+    @classmethod
+    def generate(cls):
+        pit_stops = PitStop.objects.filter(start_date__date__gte=cls.START_DATE).order_by(
+            "start_date"
+        )
+        records = []
+        previous_end = None
+        for ps in pit_stops:
+            if previous_end:
+                delta = ps.start_date - previous_end
+                records.append(
+                    {"day": ps.start_date.date(), "interval": delta.total_seconds() / 60}
+                )
+            if ps.end_date:
+                previous_end = ps.end_date
+        if not records:
+            df = pd.DataFrame({"day": [], "avg_interval": []})
+        else:
+            df = pd.DataFrame(records)
+            day_range = pd.date_range(start=cls.START_DATE, end=df["day"].max())
+            df = (
+                df.groupby("day")["interval"]
+                .mean()
+                .reindex(day_range, fill_value=0)
+                .reset_index()
+            )
+            df = df.rename(columns={"index": "day", "interval": "avg_interval"})
+        fig = px.line(df, x="day", y="avg_interval")
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")

--- a/agathe/templates/agathe/pit_stop_stats.html
+++ b/agathe/templates/agathe/pit_stop_stats.html
@@ -2,8 +2,16 @@
 
 {% block content %}
 <h2 class="mb-4">Statistiques Pit Stop</h2>
-<div class="card p-4 shadow-sm">
+<div class="card p-4 shadow-sm mb-4">
     <h5 class="card-title">Pit stops par jour</h5>
     {{ pit_stops_per_day|safe }}
+</div>
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Durée moyenne des pit stops par jour</h5>
+    {{ pit_stop_duration_avg_per_day|safe }}
+</div>
+<div class="card p-4 shadow-sm">
+    <h5 class="card-title">Temps moyen entre deux pit stops</h5>
+    {{ pit_stop_interval_avg_per_day|safe }}
 </div>
 {% endblock %}

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -3,7 +3,11 @@ from django.utils import timezone
 
 from agathe.forms.pit_stop import PitStopForm
 from agathe.models import PitStop
-from agathe.services.graph.pit_stop_timeseries import PitStopTimeseriesChart
+from agathe.services.graph.pit_stop_timeseries import (
+    PitStopTimeseriesChart,
+    PitStopDurationTimeseriesChart,
+    PitStopIntervalTimeseriesChart,
+)
 
 
 class PitStopController:
@@ -47,10 +51,16 @@ class PitStopController:
     @staticmethod
     def stats(request):
         pit_stops_per_day = PitStopTimeseriesChart.generate()
+        pit_stop_duration_avg_per_day = PitStopDurationTimeseriesChart.generate()
+        pit_stop_interval_avg_per_day = PitStopIntervalTimeseriesChart.generate()
         return render(
             request,
             "agathe/pit_stop_stats.html",
-            {"pit_stops_per_day": pit_stops_per_day},
+            {
+                "pit_stops_per_day": pit_stops_per_day,
+                "pit_stop_duration_avg_per_day": pit_stop_duration_avg_per_day,
+                "pit_stop_interval_avg_per_day": pit_stop_interval_avg_per_day,
+            },
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- chart average pit stop duration per day
- chart average time between pit stops per day

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b97e5024832989047184f8c15185