### PR TITLE
Add hourly pit stop stats tab

### DIFF
--- a/agathe/services/graph/pit_stop_timeseries.py
+++ b/agathe/services/graph/pit_stop_timeseries.py
@@ -103,3 +103,100 @@ class PitStopIntervalTimeseriesChart:
         fig = px.line(df, x="day", y="avg_interval")
         fig.update_layout(xaxis_title="Jour", yaxis_title="Interval moyen (Heures)")
         return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+class PitStopPerHourChart:
+    """Generate a line chart of pit stops per hour."""
+
+    @staticmethod
+    def generate():
+        pit_stops = PitStop.objects.filter(
+            start_date__date__gte=AgatheConstant.GRAPH_START_DATE
+        )
+        records = [{"hour": ps.start_date.hour} for ps in pit_stops]
+        hour_range = range(24)
+        if not records:
+            df = pd.DataFrame({"hour": list(hour_range), "count": [0] * 24})
+        else:
+            df = pd.DataFrame(records)
+            df = (
+                df.groupby("hour")
+                .size()
+                .reindex(hour_range, fill_value=0)
+                .reset_index(name="count")
+            )
+        fig = px.line(df, x="hour", y="count")
+        fig.update_layout(xaxis_title="Heure", yaxis_title="Nombre")
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+class PitStopDurationPerHourChart:
+    """Generate a line chart of average pit stop duration per hour."""
+
+    @staticmethod
+    def generate():
+        pit_stops = PitStop.objects.filter(
+            start_date__date__gte=AgatheConstant.GRAPH_START_DATE,
+            end_date__isnull=False,
+        )
+        records = [
+            {"hour": ps.start_date.hour, "duration": ps.duration}
+            for ps in pit_stops
+        ]
+        hour_range = range(24)
+        if not records:
+            df = pd.DataFrame({"hour": list(hour_range), "avg_duration": [0] * 24})
+        else:
+            df = pd.DataFrame(records)
+            df = (
+                df.groupby("hour")["duration"]
+                .mean()
+                .reindex(hour_range, fill_value=0)
+                .reset_index()
+            )
+            df = df.rename(columns={"duration": "avg_duration"})
+        fig = px.line(df, x="hour", y="avg_duration")
+        fig.update_layout(
+            xaxis_title="Heure", yaxis_title="Durée moyenne (Minutes)"
+        )
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")
+
+
+class PitStopIntervalPerHourChart:
+    """Generate a line chart of average time between pit stops per hour."""
+
+    @staticmethod
+    def generate():
+        pit_stops = PitStop.objects.filter(
+            start_date__date__gte=AgatheConstant.GRAPH_START_DATE
+        ).order_by("start_date")
+        records = []
+        previous_end = None
+        for ps in pit_stops:
+            if previous_end:
+                delta = ps.start_date - previous_end
+                records.append(
+                    {
+                        "hour": ps.start_date.hour,
+                        "interval": delta.total_seconds() / (60 * 60),
+                    }
+                )
+            if ps.end_date:
+                previous_end = ps.end_date
+        hour_range = range(24)
+        if not records:
+            df = pd.DataFrame({"hour": list(hour_range), "avg_interval": [0] * 24})
+        else:
+            df = pd.DataFrame(records)
+            df = (
+                df.groupby("hour")["interval"]
+                .mean()
+                .reindex(hour_range, fill_value=0)
+                .reset_index()
+            )
+            df = df.rename(columns={"interval": "avg_interval"})
+        fig = px.line(df, x="hour", y="avg_interval")
+        fig.update_layout(
+            xaxis_title="Heure", yaxis_title="Interval moyen (Heures)"
+        )
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")

--- a/agathe/templates/agathe/pit_stop_stats.html
+++ b/agathe/templates/agathe/pit_stop_stats.html
@@ -2,16 +2,39 @@
 
 {% block content %}
 <h2 class="mb-4">Statistiques Pit Stop</h2>
+<ul class="nav nav-tabs mb-4">
+    <li class="nav-item">
+        <a class="nav-link {% if tab == 'daily' %}active{% endif %}" href="?tab=daily">Par jour</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link {% if tab == 'hour' %}active{% endif %}" href="?tab=hour">Par heure</a>
+    </li>
+    </ul>
+{% if tab == 'hour' %}
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Pit stops par heure</h5>
+    {{ pit_stops_per_hour|safe }}
+    </div>
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Durée moyenne des pit stops par heure</h5>
+    {{ pit_stop_duration_avg_per_hour|safe }}
+    </div>
+<div class="card p-4 shadow-sm">
+    <h5 class="card-title">Temps moyen entre deux pit stops</h5>
+    {{ pit_stop_interval_avg_per_hour|safe }}
+    </div>
+{% else %}
 <div class="card p-4 shadow-sm mb-4">
     <h5 class="card-title">Pit stops par jour</h5>
     {{ pit_stops_per_day|safe }}
-</div>
+    </div>
 <div class="card p-4 shadow-sm mb-4">
     <h5 class="card-title">Durée moyenne des pit stops par jour</h5>
     {{ pit_stop_duration_avg_per_day|safe }}
-</div>
+    </div>
 <div class="card p-4 shadow-sm">
     <h5 class="card-title">Temps moyen entre deux pit stops</h5>
     {{ pit_stop_interval_avg_per_day|safe }}
-</div>
+    </div>
+{% endif %}
 {% endblock %}

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -7,6 +7,9 @@ from agathe.services.graph.pit_stop_timeseries import (
     PitStopTimeseriesChart,
     PitStopDurationTimeseriesChart,
     PitStopIntervalTimeseriesChart,
+    PitStopPerHourChart,
+    PitStopDurationPerHourChart,
+    PitStopIntervalPerHourChart,
 )
 
 
@@ -50,18 +53,25 @@ class PitStopController:
 
     @staticmethod
     def stats(request):
-        pit_stops_per_day = PitStopTimeseriesChart.generate()
-        pit_stop_duration_avg_per_day = PitStopDurationTimeseriesChart.generate()
-        pit_stop_interval_avg_per_day = PitStopIntervalTimeseriesChart.generate()
-        return render(
-            request,
-            "agathe/pit_stop_stats.html",
-            {
-                "pit_stops_per_day": pit_stops_per_day,
-                "pit_stop_duration_avg_per_day": pit_stop_duration_avg_per_day,
-                "pit_stop_interval_avg_per_day": pit_stop_interval_avg_per_day,
-            },
-        )
+        tab = request.GET.get("tab", "daily")
+        context = {"tab": tab}
+        if tab == "hour":
+            context.update(
+                {
+                    "pit_stops_per_hour": PitStopPerHourChart.generate(),
+                    "pit_stop_duration_avg_per_hour": PitStopDurationPerHourChart.generate(),
+                    "pit_stop_interval_avg_per_hour": PitStopIntervalPerHourChart.generate(),
+                }
+            )
+        else:
+            context.update(
+                {
+                    "pit_stops_per_day": PitStopTimeseriesChart.generate(),
+                    "pit_stop_duration_avg_per_day": PitStopDurationTimeseriesChart.generate(),
+                    "pit_stop_interval_avg_per_day": PitStopIntervalTimeseriesChart.generate(),
+                }
+            )
+        return render(request, "agathe/pit_stop_stats.html", context)
 
     @staticmethod
     def start(request):


### PR DESCRIPTION
## Summary
- add hourly chart generation utilities for pit stop stats
- show daily vs hourly stats in separate tabs and compute only when requested

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b322cbdf348329ac4046e66df40fa8