### PR TITLE
Improve finance simulator results with charts and bootstrap

### DIFF
--- a/finance_simulator/services/graph/interest_timeseries.py
+++ b/finance_simulator/services/graph/interest_timeseries.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import plotly.express as px
+
+from finance_simulator.domain.simulation_result import SimulationResult
+
+
+class InterestTimeseriesChart:
+    """Generate a line chart of interests paid per month."""
+
+    @staticmethod
+    def generate(simulation_result: SimulationResult) -> str:
+        records = [
+            {"month": amortization.month, "interest": amortization.interests}
+            for amortization in simulation_result.amortizations
+        ]
+        df = pd.DataFrame(records)
+        fig = px.line(df, x="month", y="interest")
+        fig.update_layout(xaxis_title="Mois", yaxis_title="Intérêts payés")
+        return fig.to_html(full_html=False, include_plotlyjs="cdn")

--- a/finance_simulator/templates/finance_simulator/result.html
+++ b/finance_simulator/templates/finance_simulator/result.html
@@ -1,33 +1,50 @@
 {% extends 'finance_simulator/base.html' %}
 
 {% block content %}
-<h1>Simulation:</h1>
-<ul>
-    <li>Capital emprunté: {{ simulation.capital }}€</li>
-    <li>Taux d'intérêt: {{ simulation.annual_rate }}%</li>
-    <li>Durée: {{ simulation.duration }} années</li>
-</ul>
+<div class="card mb-4 shadow-sm">
+  <div class="card-body">
+    <h1 class="card-title">Simulation</h1>
+    <ul class="list-unstyled">
+      <li>Capital emprunté: {{ simulation.capital }}€</li>
+      <li>Taux d'intérêt: {{ simulation.annual_rate }}%</li>
+      <li>Durée: {{ simulation.duration }} années</li>
+    </ul>
+    <p class="fs-5"><strong>Mensualités: {{ monthly_amount }}€</strong></p>
+  </div>
+</div>
 
-<strong>Mensualités: {{ monthly_amount }}€</strong>
+<div class="card mb-4 shadow-sm">
+  <div class="card-body">
+    <h5 class="card-title">Intérêts payés par mois</h5>
+    {{ interest_chart|safe }}
+  </div>
+</div>
 
-<table>
-    <thead>
+<button class="btn btn-secondary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#amortizationTable" aria-expanded="false" aria-controls="amortizationTable">
+  Voir le tableau d'amortissement
+</button>
+<div class="collapse" id="amortizationTable">
+  <div class="card card-body">
+    <table class="table table-striped">
+      <thead>
         <tr>
-            <th>Mois</th>
-            <th>Intérêts</th>
-            <th>Capital payé</th>
-            <th>Capital restant</th>
+          <th>Mois</th>
+          <th>Intérêts</th>
+          <th>Capital payé</th>
+          <th>Capital restant</th>
         </tr>
-    </thead>
-    <tbody>
+      </thead>
+      <tbody>
         {% for amortization in amortizations %}
         <tr>
-            <td>{{ amortization.month }}</td>
-            <td>{{ amortization.interests }}€</td>
-            <td>{{ amortization.capital_paid }}€</td>
-            <td>{{ amortization.capital_remaining }}€</td>
+          <td>{{ amortization.month }}</td>
+          <td>{{ amortization.interests }}€</td>
+          <td>{{ amortization.capital_paid }}€</td>
+          <td>{{ amortization.capital_remaining }}€</td>
         </tr>
         {% endfor %}
-    </tbody>
-</table>
+      </tbody>
+    </table>
+  </div>
+</div>
 {% endblock %}

--- a/finance_simulator/views/home.py
+++ b/finance_simulator/views/home.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 
 from ..domain.simulation import Simulation
 from ..forms import SimulationForm
+from ..services.graph.interest_timeseries import InterestTimeseriesChart
 from ..services.simulation import SimulationService
 
 
@@ -15,14 +16,16 @@ def home(request):
                 annual_rate=form.cleaned_data.get("rate"),
             )
             simulation_result = SimulationService(simulation).simulation_result
+            interest_chart = InterestTimeseriesChart.generate(simulation_result)
             return render(
                 request,
                 "finance_simulator/result.html",
                 {
                     "simulation": simulation,
                     "monthly_amount": simulation_result.monthly_amount,
-                    "amortizations": simulation_result.amortizations
-                }
+                    "amortizations": simulation_result.amortizations,
+                    "interest_chart": interest_chart,
+                },
             )
     else:
         form = SimulationForm()


### PR DESCRIPTION
## Summary
- Enhance finance simulator results page using Bootstrap cards and collapsible amortization table
- Add Plotly-based interest per month chart service and integrate into result view

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django plotly pandas` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68b5502fd3a4832992675dcc83ea5477