### PR TITLE
Add ideas document page to finance simulator

### DIFF
--- a/finance_simulator/templates/finance_simulator/document.html
+++ b/finance_simulator/templates/finance_simulator/document.html
@@ -1,0 +1,7 @@
+{% extends 'finance_simulator/base.html' %}
+
+{% block content %}
+    <h1>{{ title }}</h1>
+    <a class="btn btn-secondary btn-sm" href="{% url 'documents:document_edit' document.pk %}">Edit</a>
+    <div class="mt-4">{{ content_html }}</div>
+{% endblock %}

--- a/finance_simulator/templates/finance_simulator/header.html
+++ b/finance_simulator/templates/finance_simulator/header.html
@@ -4,5 +4,12 @@
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent">
             <span class="navbar-toggler-icon"></span>
         </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="{% url 'finance_simulator:ideas' %}">Ideas</a>
+                </li>
+            </ul>
+        </div>
     </div>
 </nav>

--- a/finance_simulator/urls.py
+++ b/finance_simulator/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
 from finance_simulator.views.home import home
+from finance_simulator.views.documents import ideas
 
 app_name = "finance_simulator"
 
 urlpatterns = [
     path("", home, name="home"),
+    path("ideas/", ideas, name="ideas"),
 ]

--- a/finance_simulator/views/documents.py
+++ b/finance_simulator/views/documents.py
@@ -1,0 +1,24 @@
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+import markdown
+
+from documents.models import Document
+from documents.constants.directories import Directories
+
+
+def _render_document(request, title: str):
+    document, _ = Document.objects.get_or_create(
+        title=title,
+        directory=Directories.FINANCE_SIMULATOR,
+        defaults={"content": ""},
+    )
+    content_html = mark_safe(markdown.markdown(document.content))
+    return render(
+        request,
+        "finance_simulator/document.html",
+        {"title": title, "content_html": content_html, "document": document},
+    )
+
+
+def ideas(request):
+    return _render_document(request, "Ideas")


### PR DESCRIPTION
## Summary
- Link Ideas page in finance simulator navigation
- Add Ideas document view and template with edit button

## Testing
- `poetry run python manage.py collectstatic --noinput`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5534df51c8329a2bb7778dd184abc