### PR TITLE
Enhance Finance Simulator form and results editing

### DIFF
--- a/finance_simulator/forms/simulation.py
+++ b/finance_simulator/forms/simulation.py
@@ -5,4 +5,10 @@ class SimulationForm(forms.Form):
     capital = forms.DecimalField(label="Capital emprunté", min_value=0, decimal_places=2, max_digits=12)
     years = forms.IntegerField(label="Années d'emprunt", min_value=1)
     rate = forms.DecimalField(label="Taux d'emprunt", min_value=0, decimal_places=2, max_digits=5)
-    comparative_rent = forms.DecimalField(label="Loyer actuel", min_value=0, decimal_places=2, max_digits=12)
+    comparative_rent = forms.DecimalField(
+        label="Loyer actuel (optionnel)",
+        min_value=0,
+        decimal_places=2,
+        max_digits=12,
+        required=False,
+    )

--- a/finance_simulator/templates/finance_simulator/home.html
+++ b/finance_simulator/templates/finance_simulator/home.html
@@ -1,10 +1,15 @@
 {% extends 'finance_simulator/base.html' %}
+{% load bootstrap5 %}
 
 {% block content %}
-<h1>Simulation de prêt</h1>
-<form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="btn btn-primary">Lancer une simulation</button>
-</form>
+<h1 class="mb-4">Simulation de prêt</h1>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form method="post">
+            {% csrf_token %}
+            {% bootstrap_form form %}
+            <button type="submit" class="btn btn-primary">Lancer une simulation</button>
+        </form>
+    </div>
+</div>
 {% endblock %}

--- a/finance_simulator/templates/finance_simulator/result.html
+++ b/finance_simulator/templates/finance_simulator/result.html
@@ -1,7 +1,13 @@
 {% extends 'finance_simulator/base.html' %}
 
 {% block content %}
-{% load readable_month %}
+{% load readable_month bootstrap5 %}
+
+<div class="d-flex justify-content-end mb-3">
+  <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editSimulationModal">
+    Modifier
+  </button>
+</div>
 
 <div class="card mb-4 shadow-sm">
   <div class="card-body">
@@ -51,4 +57,26 @@
     </table>
   </div>
 </div>
+
+<div class="modal fade" id="editSimulationModal" tabindex="-1" aria-labelledby="editSimulationModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editSimulationModalLabel">Modifier la simulation</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form method="post">
+        {% csrf_token %}
+        <div class="modal-body">
+          {% bootstrap_form form %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+          <button type="submit" class="btn btn-primary">Relancer</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
 {% endblock %}

--- a/finance_simulator/views/home.py
+++ b/finance_simulator/views/home.py
@@ -14,10 +14,18 @@ def home(request):
                 capital=form.cleaned_data.get("capital"),
                 duration=form.cleaned_data.get("years"),
                 annual_rate=form.cleaned_data.get("rate"),
-                comparative_rent=form.cleaned_data.get("comparative_rent"),
+                comparative_rent=form.cleaned_data.get("comparative_rent") or 0,
             )
             simulation_result = SimulationService(simulation).simulation_result
             interest_chart = InterestTimeseriesChart.generate(simulation_result)
+            form = SimulationForm(
+                initial={
+                    "capital": simulation.capital,
+                    "years": simulation.duration,
+                    "rate": simulation.annual_rate,
+                    "comparative_rent": simulation.comparative_rent,
+                }
+            )
             return render(
                 request,
                 "finance_simulator/result.html",
@@ -25,6 +33,7 @@ def home(request):
                     "simulation": simulation,
                     "simulation_result": simulation_result,
                     "interest_chart": interest_chart,
+                    "form": form,
                 },
             )
     else:


### PR DESCRIPTION
## Summary
- Style home simulation form with Bootstrap and mark optional fields
- Add result page modal to edit simulation parameters and rerun calculations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django==4.2` *(fails: Could not find a version that satisfies the requirement django==4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b69b25bc588329a1fa477a9a58d0a3