### PR TITLE
Add default simulation option to Finance Simulator

### DIFF
--- a/finance_simulator/templates/finance_simulator/home.html
+++ b/finance_simulator/templates/finance_simulator/home.html
@@ -10,6 +10,7 @@
             {% bootstrap_form form %}
             <button type="submit" class="btn btn-primary">Lancer une simulation</button>
         </form>
+        <a href="{% url 'finance_simulator:default_simulation' %}" class="btn btn-outline-secondary mt-3">Simulation par défaut</a>
     </div>
 </div>
 {% endblock %}

--- a/finance_simulator/urls.py
+++ b/finance_simulator/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 
-from finance_simulator.views.home import home
+from finance_simulator.views.home import default_simulation, home
 from finance_simulator.views.documents import ideas
 
 app_name = "finance_simulator"
 
 urlpatterns = [
     path("", home, name="home"),
+    path("default/", default_simulation, name="default_simulation"),
     path("ideas/", ideas, name="ideas"),
 ]

--- a/finance_simulator/views/home.py
+++ b/finance_simulator/views/home.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 
+from ..constants.default_simulation import DEFAULT_SIMULATION
 from ..domain.simulation import Simulation
 from ..forms.simulation import SimulationForm
 from ..services.graph.interest_timeseries import InterestTimeseriesChart
@@ -39,3 +40,27 @@ def home(request):
     else:
         form = SimulationForm()
     return render(request, "finance_simulator/home.html", {"form": form})
+
+
+def default_simulation(request):
+    simulation = DEFAULT_SIMULATION
+    simulation_result = SimulationService(simulation).simulation_result
+    interest_chart = InterestTimeseriesChart.generate(simulation_result)
+    form = SimulationForm(
+        initial={
+            "capital": simulation.capital,
+            "years": simulation.duration,
+            "rate": simulation.annual_rate,
+            "comparative_rent": simulation.comparative_rent,
+        }
+    )
+    return render(
+        request,
+        "finance_simulator/result.html",
+        {
+            "simulation": simulation,
+            "simulation_result": simulation_result,
+            "interest_chart": interest_chart,
+            "form": form,
+        },
+    )


### PR DESCRIPTION
## Summary
- add a dedicated view to run the DEFAULT_SIMULATION
- expose a `default/` route and home page button to launch the default simulation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b69dc2fe748329aa8808a6a7e792a2