### PR TITLE
Fix default simulation to allow editing parameters

### DIFF
--- a/finance_simulator/templates/finance_simulator/result.html
+++ b/finance_simulator/templates/finance_simulator/result.html
@@ -86,7 +86,7 @@
                     <h5 class="modal-title" id="editSimulationModalLabel">Modifier la simulation</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <form method="post">
+                <form method="post" action="{% url 'finance_simulator:home' %}">
                     {% csrf_token %}
                     <div class="modal-body">
                         {% bootstrap_form form %}


### PR DESCRIPTION
## Summary
- ensure default simulation form posts to home so parameters can be modified

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b6adf8431483298a705add2663c5c4