### PR TITLE
Refactor finance simulator form and share template

### DIFF
--- a/finance_simulator/forms/simulation.py
+++ b/finance_simulator/forms/simulation.py
@@ -3,18 +3,23 @@ from django import forms
 
 class SimulationForm(forms.Form):
     house_cost = forms.DecimalField(label="Prix du bien", min_value=0, decimal_places=2, max_digits=12)
-    initial_contribution = forms.DecimalField(label="Apport initial", min_value=0, decimal_places=2, max_digits=12)
+    initial_contribution = forms.DecimalField(
+        label="Apport initial (€)",
+        min_value=0,
+        decimal_places=2,
+        max_digits=12,
+    )
     years = forms.IntegerField(label="Années d'emprunt", min_value=1)
-    rate = forms.DecimalField(label="Taux d'emprunt", min_value=0, decimal_places=2, max_digits=5)
+    rate = forms.DecimalField(label="Taux d'emprunt (%)", min_value=0, decimal_places=2, max_digits=5)
     comparative_rent = forms.DecimalField(
-        label="Loyer actuel (optionnel)",
+        label="Loyer actuel (€/Mois)",
         min_value=0,
         decimal_places=2,
         max_digits=12,
         required=False,
     )
     duration_before_usable = forms.IntegerField(
-        label="Achat sur Plan (Nombre de mois avant livraison, optionnel)",
+        label="Achat sur Plan: Nombre de mois avant livraison",
         min_value=0,
         required=False,
     )

--- a/finance_simulator/templates/finance_simulator/home.html
+++ b/finance_simulator/templates/finance_simulator/home.html
@@ -1,13 +1,11 @@
 {% extends 'finance_simulator/base.html' %}
-{% load bootstrap5 %}
 
 {% block content %}
 <h1 class="mb-4">Simulation de prêt</h1>
 <div class="card shadow-sm">
     <div class="card-body">
         <form method="post">
-            {% csrf_token %}
-            {% bootstrap_form form %}
+            {% include 'finance_simulator/simulation_form.html' %}
             <button type="submit" class="btn btn-primary">Lancer une simulation</button>
         </form>
         <a href="{% url 'finance_simulator:default_simulation' %}" class="btn btn-outline-secondary mt-3">Simulation par défaut</a>

--- a/finance_simulator/templates/finance_simulator/result.html
+++ b/finance_simulator/templates/finance_simulator/result.html
@@ -1,7 +1,7 @@
 {% extends 'finance_simulator/base.html' %}
 
 {% block content %}
-    {% load readable_month readable_amount bootstrap5 %}
+    {% load readable_month readable_amount %}
 
     <div class="d-flex justify-content-end mb-3">
         <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#editSimulationModal">
@@ -102,9 +102,8 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <form method="post" action="{% url 'finance_simulator:home' %}">
-                    {% csrf_token %}
                     <div class="modal-body">
-                        {% bootstrap_form form %}
+                        {% include 'finance_simulator/simulation_form.html' %}
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>

--- a/finance_simulator/templates/finance_simulator/simulation_form.html
+++ b/finance_simulator/templates/finance_simulator/simulation_form.html
@@ -1,0 +1,33 @@
+{% load bootstrap5 %}
+{% csrf_token %}
+<div class="row">
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.house_cost %}
+    </div>
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.initial_contribution %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.years %}
+    </div>
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.rate %}
+    </div>
+</div>
+<hr>
+<h5>Champs optionnels</h5>
+<div class="row">
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.comparative_rent %}
+    </div>
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.duration_before_usable %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6 mb-3">
+        {% bootstrap_field form.use_real_estate_firm %}
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- split simulation fields into mandatory and optional sections
- reuse new simulation_form.html from home and result pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b6bedba0e483298f5b5b8ac6a6385a