### PR TITLE
Add side-based pit stop stats and cumulative duration chart

### DIFF
--- a/agathe/templates/agathe/pit_stop_stats.html
+++ b/agathe/templates/agathe/pit_stop_stats.html
@@ -9,6 +9,9 @@
     <li class="nav-item">
         <a class="nav-link {% if tab == 'hour' %}active{% endif %}" href="?tab=hour">Par heure</a>
     </li>
+    <li class="nav-item">
+        <a class="nav-link {% if tab == 'side' %}active{% endif %}" href="?tab=side">Par côté</a>
+    </li>
     </ul>
 {% if tab == 'hour' %}
 <div class="card p-4 shadow-sm mb-4">
@@ -23,6 +26,19 @@
     <h5 class="card-title">Temps moyen entre deux pit stops</h5>
     {{ pit_stop_interval_avg_per_hour|safe }}
     </div>
+{% elif tab == 'side' %}
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Pit stops par jour par côté</h5>
+    {{ pit_stops_per_day_by_side|safe }}
+    </div>
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Durée moyenne des pit stops par jour par côté</h5>
+    {{ pit_stop_duration_avg_per_day_by_side|safe }}
+    </div>
+<div class="card p-4 shadow-sm">
+    <h5 class="card-title">Durée totale par côté</h5>
+    {{ pit_stop_duration_total_by_side|safe }}
+    </div>
 {% else %}
 <div class="card p-4 shadow-sm mb-4">
     <h5 class="card-title">Pit stops par jour</h5>
@@ -31,6 +47,10 @@
 <div class="card p-4 shadow-sm mb-4">
     <h5 class="card-title">Durée moyenne des pit stops par jour</h5>
     {{ pit_stop_duration_avg_per_day|safe }}
+    </div>
+<div class="card p-4 shadow-sm mb-4">
+    <h5 class="card-title">Durée totale des pit stops par jour</h5>
+    {{ pit_stop_duration_total_per_day|safe }}
     </div>
 <div class="card p-4 shadow-sm">
     <h5 class="card-title">Temps moyen entre deux pit stops</h5>

--- a/agathe/views/pit_stop.py
+++ b/agathe/views/pit_stop.py
@@ -10,6 +10,10 @@ from agathe.services.graph.pit_stop_timeseries import (
     PitStopPerHourChart,
     PitStopDurationPerHourChart,
     PitStopIntervalPerHourChart,
+    PitStopDurationTotalTimeseriesChart,
+    PitStopPerDayBySideChart,
+    PitStopDurationAvgPerDayBySideChart,
+    PitStopDurationTotalBySideChart,
 )
 
 
@@ -63,12 +67,21 @@ class PitStopController:
                     "pit_stop_interval_avg_per_hour": PitStopIntervalPerHourChart.generate(),
                 }
             )
+        elif tab == "side":
+            context.update(
+                {
+                    "pit_stops_per_day_by_side": PitStopPerDayBySideChart.generate(),
+                    "pit_stop_duration_avg_per_day_by_side": PitStopDurationAvgPerDayBySideChart.generate(),
+                    "pit_stop_duration_total_by_side": PitStopDurationTotalBySideChart.generate(),
+                }
+            )
         else:
             context.update(
                 {
                     "pit_stops_per_day": PitStopTimeseriesChart.generate(),
                     "pit_stop_duration_avg_per_day": PitStopDurationTimeseriesChart.generate(),
                     "pit_stop_interval_avg_per_day": PitStopIntervalTimeseriesChart.generate(),
+                    "pit_stop_duration_total_per_day": PitStopDurationTotalTimeseriesChart.generate(),
                 }
             )
         return render(request, "agathe/pit_stop_stats.html", context)


### PR DESCRIPTION
## Summary
- add total pit stop duration timeseries
- add new "par côté" tab with side-based charts
- display donut of total duration per side

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68becbbd927c83298409cfc0c443998a