### PR TITLE
Add Silksong documents pages and shared header

### DIFF
--- a/agathe/views/documents.py
+++ b/agathe/views/documents.py
@@ -1,24 +1,15 @@
-from django.shortcuts import render
-from django.utils.safestring import mark_safe
-import markdown
-
-from documents.models import Document
 from documents.constants.directories import Directories
+from documents.views import render_document
 
 
 class DocumentController:
     @staticmethod
     def _render_document(request, title: str):
-        document, _ = Document.objects.get_or_create(
+        return render_document(
+            request,
             title=title,
             directory=Directories.AGATHE,
-            defaults={"content": ""},
-        )
-        content_html = mark_safe(markdown.markdown(document.content))
-        return render(
-            request,
-            "agathe/document.html",
-            {"title": title, "content_html": content_html, "document": document},
+            template_name="agathe/document.html",
         )
 
     @staticmethod

--- a/documents/constants/directories.py
+++ b/documents/constants/directories.py
@@ -8,4 +8,5 @@ class Directories(models.TextChoices):
     BAZAAR = "bazaar", "The Bazaar"
     CIVILIZATION7 = "civilization_7", "Civilization 7"
     FINANCE_SIMULATOR = "finance", "Finance Simulator"
+    SILKSONG = "silksong", "Silksong"
     RUNETERRA = "runeterra", "Runeterra"

--- a/documents/templates/documents/document_form.html
+++ b/documents/templates/documents/document_form.html
@@ -5,6 +5,9 @@
 <h1>{% if form.instance.pk %}Edit{% else %}New{% endif %} Document</h1>
 <form method="post" class="mt-4">
     {% csrf_token %}
+    {% if redirect_to %}
+    <input type="hidden" name="{{ redirect_field_name|default:'next' }}" value="{{ redirect_to }}">
+    {% endif %}
     <div class="mb-3">
         <label for="id_title" class="form-label">Titre</label>
         {{ form.title|add_class:'form-control' }}

--- a/documents/views/__init__.py
+++ b/documents/views/__init__.py
@@ -3,4 +3,5 @@ from .document import (
     document_detail,
     DocumentCreateView,
     DocumentUpdateView,
+    render_document,
 )

--- a/documents/views/document.py
+++ b/documents/views/document.py
@@ -52,3 +52,23 @@ class DocumentUpdateView(UpdateView):
     form_class = DocumentForm
     template_name = "documents/document_form.html"
     success_url = reverse_lazy("documents:document_list")
+    redirect_field_name = "next"
+
+    def _get_redirect_to(self):
+        return self.request.POST.get(self.redirect_field_name) or self.request.GET.get(
+            self.redirect_field_name
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        redirect_to = self._get_redirect_to()
+        if redirect_to:
+            context["redirect_to"] = redirect_to
+            context["redirect_field_name"] = self.redirect_field_name
+        return context
+
+    def get_success_url(self):
+        redirect_to = self._get_redirect_to()
+        if redirect_to:
+            return redirect_to
+        return super().get_success_url()

--- a/finance_simulator/views/documents.py
+++ b/finance_simulator/views/documents.py
@@ -1,22 +1,13 @@
-from django.shortcuts import render
-from django.utils.safestring import mark_safe
-import markdown
-
-from documents.models import Document
 from documents.constants.directories import Directories
+from documents.views import render_document
 
 
 def _render_document(request, title: str):
-    document, _ = Document.objects.get_or_create(
+    return render_document(
+        request,
         title=title,
         directory=Directories.FINANCE_SIMULATOR,
-        defaults={"content": ""},
-    )
-    content_html = mark_safe(markdown.markdown(document.content))
-    return render(
-        request,
-        "finance_simulator/document.html",
-        {"title": title, "content_html": content_html, "document": document},
+        template_name="finance_simulator/document.html",
     )
 
 

--- a/runeterra/views/documents.py
+++ b/runeterra/views/documents.py
@@ -1,22 +1,13 @@
-from django.shortcuts import render
-from django.utils.safestring import mark_safe
-import markdown
-
-from documents.models import Document
 from documents.constants.directories import Directories
+from documents.views import render_document
 
 
 def _render_document(request, title: str):
-    document, _ = Document.objects.get_or_create(
+    return render_document(
+        request,
         title=title,
         directory=Directories.RUNETERRA,
-        defaults={"content": ""},
-    )
-    content_html = mark_safe(markdown.markdown(document.content))
-    return render(
-        request,
-        "runeterra/document.html",
-        {"title": title, "content_html": content_html},
+        template_name="runeterra/document.html",
     )
 
 

--- a/silksong/templates/silksong/base.html
+++ b/silksong/templates/silksong/base.html
@@ -5,39 +5,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SilkSong</title>
+    <title>{% block title %}SilkSong{% endblock %}</title>
     {% bootstrap_css %}
     {% bootstrap_javascript %}
 </head>
 <body class="bg-light">
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container">
-        <a class="navbar-brand" href="{% url 'silksong:home' %}">SilkSong</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#silksongNavbar" aria-controls="silksongNavbar" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="silksongNavbar">
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'home' %}active{% endif %}" {% if active_page == 'home' %}aria-current="page"{% endif %} href="{% url 'silksong:home' %}">Accueil</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'speedrun' %}active{% endif %}" {% if active_page == 'speedrun' %}aria-current="page"{% endif %} href="{% url 'silksong:speedrun_sessions' %}">Speedrun</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'steel_soul' %}active{% endif %}" {% if active_page == 'steel_soul' %}aria-current="page"{% endif %} href="{% url 'silksong:steel_soul_sessions' %}">Steel Soul</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'boss_fight' %}active{% endif %}" {% if active_page == 'boss_fight' %}aria-current="page"{% endif %} href="{% url 'silksong:boss_fight_sessions' %}">Boss Fight</a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</nav>
+{% include "silksong/header.html" %}
+
 <div class="container py-4">
     {% block content %}{% endblock %}
+
+    {% block scripts %}{% endblock %}
 </div>
-{% block scripts %}{% endblock %}
 <script src="{% static 'keystrokes.js' %}"></script>
 </body>
 </html>

--- a/silksong/templates/silksong/document.html
+++ b/silksong/templates/silksong/document.html
@@ -1,0 +1,8 @@
+{% extends "silksong/base.html" %}
+
+{% block title %}{{ title }} - SilkSong{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">{{ title }}</h1>
+<div class="mt-4">{{ content_html }}</div>
+{% endblock %}

--- a/silksong/templates/silksong/document.html
+++ b/silksong/templates/silksong/document.html
@@ -3,6 +3,11 @@
 {% block title %}{{ title }} - SilkSong{% endblock %}
 
 {% block content %}
-<h1 class="mb-4">{{ title }}</h1>
+<div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+    <h1 class="mb-0">{{ title }}</h1>
+    {% if edit_url %}
+    <a class="btn btn-outline-secondary" href="{{ edit_url }}">Edit</a>
+    {% endif %}
+</div>
 <div class="mt-4">{{ content_html }}</div>
 {% endblock %}

--- a/silksong/templates/silksong/header.html
+++ b/silksong/templates/silksong/header.html
@@ -1,0 +1,43 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light px-3">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{% url 'silksong:home' %}">SilkSong</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#silksongNavbar"
+                aria-controls="silksongNavbar" aria-expanded="false" aria-label="Basculer la navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="silksongNavbar">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'home' %} active{% endif %}"
+                       {% if active_page == 'home' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:home' %}">Accueil</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'speedrun' %} active{% endif %}"
+                       {% if active_page == 'speedrun' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:speedrun_sessions' %}">Speedrun</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'steel_soul' %} active{% endif %}"
+                       {% if active_page == 'steel_soul' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:steel_soul_sessions' %}">Steel Soul</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'boss_fight' %} active{% endif %}"
+                       {% if active_page == 'boss_fight' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:boss_fight_sessions' %}">Boss Fight</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'objectives' %} active{% endif %}"
+                       {% if active_page == 'objectives' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:objectives' %}">Objectives</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link{% if active_page == 'ideas' %} active{% endif %}"
+                       {% if active_page == 'ideas' %}aria-current="page"{% endif %}
+                       href="{% url 'silksong:ideas' %}">Ideas</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>

--- a/silksong/urls.py
+++ b/silksong/urls.py
@@ -3,6 +3,8 @@ from django.urls import path
 from silksong.views import (
     boss_fight_sessions,
     home,
+    ideas,
+    objectives,
     speedrun_sessions,
     steel_soul_sessions,
 )
@@ -11,6 +13,8 @@ app_name = "silksong"
 
 urlpatterns = [
     path("", home, name="home"),
+    path("objectives/", objectives, name="objectives"),
+    path("ideas/", ideas, name="ideas"),
     path("speedrun/", speedrun_sessions, name="speedrun_sessions"),
     path("steel-soul/", steel_soul_sessions, name="steel_soul_sessions"),
     path("boss-fight/", boss_fight_sessions, name="boss_fight_sessions"),

--- a/silksong/views/__init__.py
+++ b/silksong/views/__init__.py
@@ -1,3 +1,4 @@
+from .documents import ideas, objectives
 from .home import home
 from .sessions import boss_fight_sessions, speedrun_sessions, steel_soul_sessions
 
@@ -6,4 +7,6 @@ __all__ = [
     "boss_fight_sessions",
     "speedrun_sessions",
     "steel_soul_sessions",
+    "objectives",
+    "ideas",
 ]

--- a/silksong/views/documents.py
+++ b/silksong/views/documents.py
@@ -1,0 +1,32 @@
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+import markdown
+
+from documents.models import Document
+from documents.constants.directories import Directories
+
+
+def _render_document(request, title: str, *, active_page: str):
+    document, _ = Document.objects.get_or_create(
+        title=title,
+        directory=Directories.SILKSONG,
+        defaults={"content": ""},
+    )
+    content_html = mark_safe(markdown.markdown(document.content))
+    return render(
+        request,
+        "silksong/document.html",
+        {
+            "title": title,
+            "content_html": content_html,
+            "active_page": active_page,
+        },
+    )
+
+
+def objectives(request):
+    return _render_document(request, "Objectives", active_page="objectives")
+
+
+def ideas(request):
+    return _render_document(request, "Ideas", active_page="ideas")

--- a/silksong/views/documents.py
+++ b/silksong/views/documents.py
@@ -1,34 +1,15 @@
-from urllib.parse import urlencode
-
-from django.shortcuts import render
-from django.urls import reverse
-from django.utils.safestring import mark_safe
-import markdown
-
-from documents.models import Document
 from documents.constants.directories import Directories
+from documents.views import render_document
 
 
 def _render_document(request, title: str, *, active_page: str):
-    document, _ = Document.objects.get_or_create(
+    return render_document(
+        request,
         title=title,
         directory=Directories.SILKSONG,
-        defaults={"content": ""},
-    )
-    content_html = mark_safe(markdown.markdown(document.content))
-    redirect_to = request.get_full_path()
-    edit_url = reverse("documents:document_edit", args=[document.pk])
-    if redirect_to:
-        edit_url = f"{edit_url}?{urlencode({'next': redirect_to})}"
-    return render(
-        request,
-        "silksong/document.html",
-        {
-            "title": title,
-            "content_html": content_html,
-            "active_page": active_page,
-            "edit_url": edit_url,
-        },
+        template_name="silksong/document.html",
+        extra_context={"active_page": active_page},
+        include_edit_url=True,
     )
 
 

--- a/silksong/views/documents.py
+++ b/silksong/views/documents.py
@@ -1,4 +1,7 @@
+from urllib.parse import urlencode
+
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 import markdown
 
@@ -13,6 +16,10 @@ def _render_document(request, title: str, *, active_page: str):
         defaults={"content": ""},
     )
     content_html = mark_safe(markdown.markdown(document.content))
+    redirect_to = request.get_full_path()
+    edit_url = reverse("documents:document_edit", args=[document.pk])
+    if redirect_to:
+        edit_url = f"{edit_url}?{urlencode({'next': redirect_to})}"
     return render(
         request,
         "silksong/document.html",
@@ -20,6 +27,7 @@ def _render_document(request, title: str, *, active_page: str):
             "title": title,
             "content_html": content_html,
             "active_page": active_page,
+            "edit_url": edit_url,
         },
     )
 


### PR DESCRIPTION
## Summary
- refactor the SilkSong base template to include a shared header partial consistent with other apps
- add ideas and objectives document views, templates, and routes backed by the documents app
- register SilkSong in the shared documents directory choices for markdown storage

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68cc2f42af1883298705c77e5436d9e1