### PR TITLE
Add speedrun document page

### DIFF
--- a/documents/constants/directories.py
+++ b/documents/constants/directories.py
@@ -9,3 +9,4 @@ class Directories(models.TextChoices):
     CIVILIZATION7 = "civilization_7", "Civilization 7"
     FINANCE_SIMULATOR = "finance", "Finance Simulator"
     RUNETERRA = "runeterra", "Runeterra"
+    SPEEDRUN = "speedrun", "Speedrun"

--- a/games_collection/templates/games_collection/speedrun.html
+++ b/games_collection/templates/games_collection/speedrun.html
@@ -1,0 +1,6 @@
+{% extends 'games_collection/base.html' %}
+
+{% block content %}
+    <h2>{{ title }}</h2>
+    <div class="mt-3">{{ content_html }}</div>
+{% endblock %}

--- a/games_collection/urls.py
+++ b/games_collection/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from games_collection.views.home import home
 from games_collection.views.back_to_the_dawn import back_to_the_dawn
 from games_collection.views.civilization_7 import civilization_7
+from games_collection.views.home import home
+from games_collection.views.speedrun import speedrun
 
 app_name = 'games_collection'
 
@@ -10,4 +11,5 @@ urlpatterns = [
     path('', home, name='home'),
     path('back_to_the_dawn/', back_to_the_dawn, name='back_to_the_dawn'),
     path('civilization_7/', civilization_7, name='civilization_7'),
+    path('speedrun/', speedrun, name='speedrun'),
 ]

--- a/games_collection/views/home.py
+++ b/games_collection/views/home.py
@@ -13,5 +13,10 @@ def home(request):
             "url": reverse("games_collection:civilization_7"),
             "color": "#2C3E50",
         },
+        {
+            "name": "Speedrun",
+            "url": reverse("games_collection:speedrun"),
+            "color": "#E67E22",
+        },
     ]
     return render(request, "games_collection/home.html", {"games": games})

--- a/games_collection/views/speedrun.py
+++ b/games_collection/views/speedrun.py
@@ -1,0 +1,22 @@
+import markdown
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
+
+from documents.constants.directories import Directories
+from documents.models import Document
+
+
+def speedrun(request):
+    document, _ = Document.objects.get_or_create(
+        title="Balatro",
+        directory=Directories.SPEEDRUN,
+        defaults={"content": ""},
+    )
+
+    content_html = mark_safe(markdown.markdown(document.content))
+
+    return render(
+        request,
+        "games_collection/speedrun.html",
+        {"title": document.title, "content_html": content_html},
+    )


### PR DESCRIPTION
## Summary
- add a Speedrun document page that auto-creates a "Balatro" note for the section
- expose the new page in the games collection home and routing
- register the Speedrun directory so related documents can be stored

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ce753efedc83299a870d51f5ced59c