### PR TITLE
Add win rate dashboard with filters

### DIFF
--- a/altered/constants/win_rate_scope.py
+++ b/altered/constants/win_rate_scope.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class WinRateScope(models.TextChoices):
+    ALL = "all", "Tous les matchs"
+    FACTION = "faction", "Par faction"
+    CHAMPION = "champion", "Par champion"
+    DECK = "deck", "Par deck"

--- a/altered/forms/win_rate_filter.py
+++ b/altered/forms/win_rate_filter.py
@@ -1,0 +1,56 @@
+from django import forms
+
+from altered.constants.faction import Faction
+from altered.constants.win_rate_scope import WinRateScope
+from altered.models import Champion, Deck
+
+
+class WinRateFilterForm(forms.Form):
+    scope = forms.ChoiceField(
+        choices=WinRateScope.choices,
+        required=False,
+        initial=WinRateScope.ALL,
+        label="Scope",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    faction = forms.ChoiceField(
+        choices=[("", "Sélectionnez une faction")] + list(Faction.choices),
+        required=False,
+        label="Faction",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    champion = forms.ModelChoiceField(
+        queryset=Champion.objects.none(),
+        required=False,
+        label="Champion",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    deck = forms.ModelChoiceField(
+        queryset=Deck.objects.none(),
+        required=False,
+        label="Deck",
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    achievement_only = forms.BooleanField(
+        required=False,
+        label="Achievement only",
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["champion"].queryset = Champion.objects.all().order_by("name")
+        self.fields["champion"].empty_label = "Sélectionnez un champion"
+        self.fields["deck"].queryset = Deck.objects.filter(is_active=True).order_by("name")
+        self.fields["deck"].empty_label = "Sélectionnez un deck"
+
+    def clean(self):
+        cleaned_data = super().clean()
+        scope = cleaned_data.get("scope") or WinRateScope.ALL
+        if scope == WinRateScope.FACTION and not cleaned_data.get("faction"):
+            self.add_error("faction", "Veuillez choisir une faction.")
+        if scope == WinRateScope.CHAMPION and not cleaned_data.get("champion"):
+            self.add_error("champion", "Veuillez choisir un champion.")
+        if scope == WinRateScope.DECK and not cleaned_data.get("deck"):
+            self.add_error("deck", "Veuillez choisir un deck.")
+        return cleaned_data

--- a/altered/services/__init__.py
+++ b/altered/services/__init__.py
@@ -2,10 +2,12 @@ from .altered_fetch_deck_data import AlteredFetchDeckDataService
 from .altered_fetch_unique_flip_data import AlteredFetchUniqueFlipDataService
 from .deck_game_stats import DeckGameStatsService
 from .meta_game_stats import MetaGameStatsService
+from .win_rate_stats import WinRateStatsService
 
 __all__ = [
     'AlteredFetchDeckDataService',
     'AlteredFetchUniqueFlipDataService',
     'DeckGameStatsService',
     'MetaGameStatsService',
+    'WinRateStatsService',
 ]

--- a/altered/services/win_rate_stats.py
+++ b/altered/services/win_rate_stats.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from django.db.models import Count, Q, QuerySet
+
+from altered.constants.win_rate_scope import WinRateScope
+from altered.models import Champion, Deck, Game
+from altered.value_objects import ChampionWinRate
+
+
+class WinRateStatsService:
+    def __init__(
+        self,
+        scope: str = WinRateScope.ALL,
+        faction: Optional[str] = None,
+        champion: Optional[Champion] = None,
+        deck: Optional[Deck] = None,
+    ):
+        self.scope = scope or WinRateScope.ALL
+        self.faction = faction
+        self.champion = champion
+        self.deck = deck
+        self.games: QuerySet[Game] = self.get_games()
+        self.result: list[ChampionWinRate] = []
+        self.compute()
+
+    def get_games(self) -> QuerySet[Game]:
+        games = Game.objects.select_related("deck", "deck__champion", "opponent_champion")
+        if self.scope == WinRateScope.FACTION and self.faction:
+            return games.filter(deck__champion__faction=self.faction)
+        if self.scope == WinRateScope.CHAMPION and self.champion:
+            return games.filter(deck__champion=self.champion)
+        if self.scope == WinRateScope.DECK and self.deck:
+            return games.filter(deck=self.deck)
+        return games
+
+    def compute(self) -> None:
+        stats = (
+            self.games.values("opponent_champion")
+            .annotate(
+                match_number=Count("id"),
+                win_number=Count("id", filter=Q(is_win=True)),
+            )
+        )
+        stats_map = {
+            entry["opponent_champion"]: entry for entry in stats
+        }
+        champions = Champion.objects.all().order_by("name")
+        for champion in champions:
+            data = stats_map.get(
+                champion.pk,
+                {"match_number": 0, "win_number": 0},
+            )
+            match_number = data["match_number"]
+            win_number = data["win_number"]
+            win_ratio = (
+                round(win_number / match_number * 100, 2)
+                if match_number
+                else None
+            )
+            ratio_color = self.get_ratio_color(win_ratio)
+            ratio_text_color = self.get_ratio_text_color(win_ratio)
+            achievement_color = self.get_achievement_color(match_number, win_number)
+            self.result.append(
+                ChampionWinRate(
+                    champion=champion,
+                    match_number=match_number,
+                    win_number=win_number,
+                    win_ratio=win_ratio,
+                    ratio_color=ratio_color,
+                    ratio_text_color=ratio_text_color,
+                    achievement_color=achievement_color,
+                )
+            )
+
+    @staticmethod
+    def get_ratio_color(win_ratio: Optional[float]) -> str:
+        if win_ratio is None:
+            return "#e9ecef"
+        ratio = max(0.0, min(win_ratio, 100.0))
+        red = (220, 53, 69)
+        orange = (253, 126, 20)
+        green = (25, 135, 84)
+        if ratio <= 50:
+            factor = ratio / 50
+            color = tuple(
+                int(red[idx] + (orange[idx] - red[idx]) * factor)
+                for idx in range(3)
+            )
+        else:
+            factor = (ratio - 50) / 50
+            color = tuple(
+                int(orange[idx] + (green[idx] - orange[idx]) * factor)
+                for idx in range(3)
+            )
+        return "#{:02x}{:02x}{:02x}".format(*color)
+
+    @staticmethod
+    def get_achievement_color(match_number: int, win_number: int) -> str:
+        if match_number == 0:
+            return "#adb5bd"
+        if win_number > 0:
+            return "#198754"
+        return "#dc3545"
+
+    @staticmethod
+    def get_ratio_text_color(win_ratio: Optional[float]) -> str:
+        if win_ratio is None:
+            return "#212529"
+        if win_ratio <= 20 or win_ratio >= 60:
+            return "#ffffff"
+        return "#212529"

--- a/altered/templates/altered/header.html
+++ b/altered/templates/altered/header.html
@@ -16,6 +16,9 @@
                     <a class="nav-link" href="{% url 'altered:meta_stats' %}">Meta Stats</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="{% url 'altered:win_rate' %}">Win Rate</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="{% url 'altered:career' %}">Career</a>
                 </li>
                 <li class="nav-item">

--- a/altered/templates/altered/win_rate.html
+++ b/altered/templates/altered/win_rate.html
@@ -1,0 +1,152 @@
+{% extends 'altered/base.html' %}
+
+{% block content %}
+<div class="container mt-4 win-rate-page">
+    <h2 class="mb-3">Win Rate Overview</h2>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <form method="get" class="row gy-3 gx-3 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label" for="{{ form.scope.id_for_label }}">{{ form.scope.label }}</label>
+                    {{ form.scope }}
+                    {% if form.scope.errors %}
+                        <div class="text-danger small">{{ form.scope.errors|join:', ' }}</div>
+                    {% endif %}
+                </div>
+                <div class="col-md-3 scope-field d-none" data-scope="faction">
+                    <label class="form-label" for="{{ form.faction.id_for_label }}">{{ form.faction.label }}</label>
+                    {{ form.faction }}
+                    {% if form.faction.errors %}
+                        <div class="text-danger small">{{ form.faction.errors|join:', ' }}</div>
+                    {% endif %}
+                </div>
+                <div class="col-md-3 scope-field d-none" data-scope="champion">
+                    <label class="form-label" for="{{ form.champion.id_for_label }}">{{ form.champion.label }}</label>
+                    {{ form.champion }}
+                    {% if form.champion.errors %}
+                        <div class="text-danger small">{{ form.champion.errors|join:', ' }}</div>
+                    {% endif %}
+                </div>
+                <div class="col-md-3 scope-field d-none" data-scope="deck">
+                    <label class="form-label" for="{{ form.deck.id_for_label }}">{{ form.deck.label }}</label>
+                    {{ form.deck }}
+                    {% if form.deck.errors %}
+                        <div class="text-danger small">{{ form.deck.errors|join:', ' }}</div>
+                    {% endif %}
+                </div>
+                <div class="col-md-3 col-lg-2">
+                    <div class="form-check form-switch">
+                        {{ form.achievement_only }}
+                        <label class="form-check-label" for="{{ form.achievement_only.id_for_label }}">{{ form.achievement_only.label }}</label>
+                    </div>
+                </div>
+                <div class="col-md-3 col-lg-2">
+                    <button type="submit" class="btn btn-primary w-100">Appliquer</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped align-middle">
+            <thead>
+            <tr>
+                <th>Champion</th>
+                <th>Faction</th>
+                <th class="text-center">Matches</th>
+                <th class="text-center">Wins</th>
+                <th class="text-center">Win Rate</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for stat in stats %}
+                <tr>
+                    <td>{{ stat.champion.name }}</td>
+                    <td>{{ stat.champion.faction }}</td>
+                    <td class="text-center">{{ stat.match_number }}</td>
+                    <td class="text-center">{{ stat.win_number }}</td>
+                    <td class="win-rate-cell"
+                        {% if achievement_only %}
+                            {% if not stat.has_game %}
+                                title="Not played yet"
+                            {% elif stat.has_win %}
+                                title="Win already achieved"
+                            {% else %}
+                                title="Played but not won"
+                            {% endif %}
+                        {% else %}
+                            {% if stat.win_ratio is not None %}
+                                title="Win rate: {{ stat.win_ratio }}%"
+                            {% else %}
+                                title="No games recorded"
+                            {% endif %}
+                        {% endif %}
+                        style="background-color: {% if achievement_only %}{{ stat.achievement_color }}{% else %}{{ stat.ratio_color }}{% endif %}; color: {% if achievement_only %}#212529{% else %}{{ stat.ratio_text_color }}{% endif %};">
+                        {% if achievement_only %}
+                            {% if stat.has_game %}
+                                {% if stat.has_win %}
+                                    <span class="visually-hidden">Win recorded</span>
+                                {% else %}
+                                    <span class="visually-hidden">No win yet</span>
+                                {% endif %}
+                            {% else %}
+                                <span class="visually-hidden">Not played</span>
+                            {% endif %}
+                            <span aria-hidden="true">&nbsp;</span>
+                        {% else %}
+                            {% if stat.win_ratio is not None %}
+                                {{ stat.win_ratio }}%
+                            {% else %}
+                                —
+                            {% endif %}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="5" class="text-center">No champion data available.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const scopeSelect = document.getElementById('id_scope');
+        const scopeFields = document.querySelectorAll('.scope-field');
+
+        function toggleScopeFields() {
+            const value = scopeSelect ? scopeSelect.value : '';
+            scopeFields.forEach((field) => {
+                if (field.dataset.scope === value) {
+                    field.classList.remove('d-none');
+                } else {
+                    field.classList.add('d-none');
+                }
+            });
+        }
+
+        if (scopeSelect) {
+            toggleScopeFields();
+            scopeSelect.addEventListener('change', toggleScopeFields);
+        }
+    });
+</script>
+<style>
+    .win-rate-page .win-rate-cell {
+        text-align: center;
+        font-weight: 600;
+        transition: background-color 0.2s ease-in-out;
+    }
+
+    .win-rate-page .win-rate-cell span[aria-hidden="true"] {
+        display: inline-block;
+        width: 100%;
+    }
+</style>
+{% endblock %}

--- a/altered/tests/test_win_rate_stats_service.py
+++ b/altered/tests/test_win_rate_stats_service.py
@@ -1,0 +1,105 @@
+from django.test import TestCase
+
+from altered.constants.win_rate_scope import WinRateScope
+from altered.models import Champion, Deck, Game
+from altered.services.win_rate_stats import WinRateStatsService
+
+
+class WinRateStatsServiceTests(TestCase):
+    def setUp(self):
+        self.alpha = Champion.objects.create(name="Alpha", faction="AXIOM")
+        self.beta = Champion.objects.create(name="Beta", faction="BRAVOS")
+        self.gamma = Champion.objects.create(name="Gamma", faction="LYRA")
+        self.delta = Champion.objects.create(name="Delta", faction="MUNA")
+
+        self.deck_alpha = Deck.objects.create(name="Deck Alpha", champion=self.alpha, altered_id="deck-alpha")
+        self.deck_beta = Deck.objects.create(name="Deck Beta", champion=self.beta, altered_id="deck-beta")
+
+        Game.objects.create(deck=self.deck_alpha, opponent_champion=self.beta, is_win=True)
+        Game.objects.create(deck=self.deck_alpha, opponent_champion=self.beta, is_win=False)
+        Game.objects.create(deck=self.deck_alpha, opponent_champion=self.gamma, is_win=True)
+        Game.objects.create(deck=self.deck_beta, opponent_champion=self.alpha, is_win=False)
+
+    def test_default_scope_includes_all_champions(self):
+        service = WinRateStatsService()
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+        gamma_stat = next(stat for stat in service.result if stat.champion == self.gamma)
+        delta_stat = next(stat for stat in service.result if stat.champion == self.delta)
+
+        self.assertEqual(alpha_stat.match_number, 1)
+        self.assertEqual(alpha_stat.win_number, 0)
+        self.assertIsNone(alpha_stat.win_ratio)
+
+        self.assertEqual(beta_stat.match_number, 2)
+        self.assertEqual(beta_stat.win_number, 1)
+        self.assertEqual(beta_stat.win_ratio, 50.0)
+
+        self.assertEqual(gamma_stat.match_number, 1)
+        self.assertEqual(gamma_stat.win_number, 1)
+        self.assertEqual(gamma_stat.win_ratio, 100.0)
+
+        self.assertEqual(delta_stat.match_number, 0)
+        self.assertEqual(delta_stat.win_number, 0)
+        self.assertIsNone(delta_stat.win_ratio)
+
+    def test_ratio_colors_follow_gradient(self):
+        service = WinRateStatsService()
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+        gamma_stat = next(stat for stat in service.result if stat.champion == self.gamma)
+
+        self.assertEqual(alpha_stat.ratio_color, "#dc3545")
+        self.assertEqual(alpha_stat.ratio_text_color, "#ffffff")
+
+        self.assertEqual(beta_stat.ratio_color, "#fd7e14")
+        self.assertEqual(beta_stat.ratio_text_color, "#212529")
+
+        self.assertEqual(gamma_stat.ratio_color, "#198754")
+        self.assertEqual(gamma_stat.ratio_text_color, "#ffffff")
+
+    def test_achievement_colors(self):
+        service = WinRateStatsService()
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+        delta_stat = next(stat for stat in service.result if stat.champion == self.delta)
+
+        self.assertEqual(alpha_stat.achievement_color, "#dc3545")
+        self.assertEqual(beta_stat.achievement_color, "#198754")
+        self.assertEqual(delta_stat.achievement_color, "#adb5bd")
+
+    def test_scope_filter_by_faction(self):
+        service = WinRateStatsService(scope=WinRateScope.FACTION, faction="AXIOM")
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+
+        self.assertEqual(alpha_stat.match_number, 0)
+        self.assertEqual(alpha_stat.win_number, 0)
+        self.assertIsNone(alpha_stat.win_ratio)
+
+        self.assertEqual(beta_stat.match_number, 2)
+        self.assertEqual(beta_stat.win_number, 1)
+
+    def test_scope_filter_by_champion(self):
+        service = WinRateStatsService(scope=WinRateScope.CHAMPION, champion=self.beta)
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+
+        self.assertEqual(alpha_stat.match_number, 1)
+        self.assertEqual(alpha_stat.win_number, 0)
+        self.assertIsNone(beta_stat.win_ratio)
+
+    def test_scope_filter_by_deck(self):
+        service = WinRateStatsService(scope=WinRateScope.DECK, deck=self.deck_beta)
+
+        alpha_stat = next(stat for stat in service.result if stat.champion == self.alpha)
+        beta_stat = next(stat for stat in service.result if stat.champion == self.beta)
+
+        self.assertEqual(alpha_stat.match_number, 1)
+        self.assertEqual(alpha_stat.win_number, 0)
+        self.assertEqual(beta_stat.match_number, 0)

--- a/altered/urls.py
+++ b/altered/urls.py
@@ -8,6 +8,7 @@ from altered.views.unique_flip import (
     unique_flip_list_view,
     unique_flip_detail_view,
 )
+from altered.views.win_rate import win_rate_view
 
 app_name = "altered"
 
@@ -16,6 +17,7 @@ urlpatterns = [
     path('game/', game_form_view, name='game_form'),
     path('decks/', deck_stats_view, name='deck_stats'),
     path('meta/', meta_stats_view, name='meta_stats'),
+    path('win-rate/', win_rate_view, name='win_rate'),
     path('career/', career_view, name='career'),
     path('flips/', unique_flip_list_view, name='unique_flip_list'),
     path('flips/<int:flip_id>/', unique_flip_detail_view, name='unique_flip_detail'),

--- a/altered/value_objects/__init__.py
+++ b/altered/value_objects/__init__.py
@@ -1,3 +1,4 @@
 from .deck_game_stats import DeckGameStats
 from .champion_game_stats import ChampionGameStats
 from .career_champion_stats import CareerChampionStats
+from .champion_win_rate import ChampionWinRate

--- a/altered/value_objects/champion_win_rate.py
+++ b/altered/value_objects/champion_win_rate.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from altered.models import Champion
+
+
+@dataclass
+class ChampionWinRate:
+    champion: Champion
+    match_number: int = 0
+    win_number: int = 0
+    win_ratio: Optional[float] = None
+    ratio_color: str = "#e9ecef"
+    ratio_text_color: str = "#212529"
+    achievement_color: str = "#adb5bd"
+
+    @property
+    def has_game(self) -> bool:
+        return self.match_number > 0
+
+    @property
+    def has_win(self) -> bool:
+        return self.win_number > 0

--- a/altered/views/__init__.py
+++ b/altered/views/__init__.py
@@ -2,4 +2,5 @@ from .game import game_form_view
 from .deck_stats import deck_stats_view
 from .meta_stats import meta_stats_view
 from .unique_flip import unique_flip_list_view
+from .win_rate import win_rate_view
 

--- a/altered/views/win_rate.py
+++ b/altered/views/win_rate.py
@@ -1,0 +1,36 @@
+from django.shortcuts import render
+
+from altered.constants.win_rate_scope import WinRateScope
+from altered.forms.win_rate_filter import WinRateFilterForm
+from altered.services.win_rate_stats import WinRateStatsService
+
+
+def win_rate_view(request):
+    if request.GET:
+        form = WinRateFilterForm(request.GET)
+        if form.is_valid():
+            scope = form.cleaned_data.get("scope") or WinRateScope.ALL
+            faction = form.cleaned_data.get("faction")
+            champion = form.cleaned_data.get("champion")
+            deck = form.cleaned_data.get("deck")
+            achievement_only = form.cleaned_data.get("achievement_only")
+            service = WinRateStatsService(
+                scope=scope,
+                faction=faction,
+                champion=champion,
+                deck=deck,
+            )
+        else:
+            service = WinRateStatsService()
+            achievement_only = bool(form.data.get("achievement_only"))
+    else:
+        form = WinRateFilterForm(initial={"scope": WinRateScope.ALL})
+        service = WinRateStatsService()
+        achievement_only = False
+
+    context = {
+        "form": form,
+        "stats": service.result,
+        "achievement_only": achievement_only,
+    }
+    return render(request, "altered/win_rate.html", context)


### PR DESCRIPTION
## Summary
- add a win rate service and supporting data objects to compute colored ratios per champion
- expose a win rate page with scope filters, achievement toggle, and navigation entry
- cover the win rate service with unit tests for filters, gradient colors, and achievement logic

## Testing
- pytest altered/tests *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68ce7da26c9883298111e97460f959b4