### PR TITLE
Adjust career colors and enhance game form filtering

### DIFF
--- a/altered/forms/new_game.py
+++ b/altered/forms/new_game.py
@@ -1,9 +1,18 @@
+import json
+
 from django import forms
 
-from altered.models import Game, Deck
+from altered.constants.faction import Faction
+from altered.models import Champion, Deck, Game
 
 
 class GameForm(forms.ModelForm):
+    opponent_faction = forms.ChoiceField(
+        choices=[('', 'All factions')] + list(Faction.choices),
+        required=False,
+        label='Opponent faction',
+    )
+
     class Meta:
         model = Game
         fields = ['deck', 'opponent_champion', 'comment', 'is_win']
@@ -14,3 +23,10 @@ class GameForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['deck'].queryset = Deck.objects.filter(is_active=True)
+        champion_field = self.fields['opponent_champion']
+        champion_queryset = Champion.objects.order_by('faction', 'name')
+        champion_field.queryset = champion_queryset
+        champion_field.widget.attrs['data-champion-factions'] = json.dumps({
+            str(champion.pk): champion.faction for champion in champion_queryset
+        })
+        self.order_fields(['deck', 'opponent_faction', 'opponent_champion', 'comment', 'is_win'])

--- a/altered/services/win_rate_stats.py
+++ b/altered/services/win_rate_stats.py
@@ -54,20 +54,25 @@ class WinRateStatsService:
             )
             match_number = data["match_number"]
             win_number = data["win_number"]
-            win_ratio = (
+            ratio_value = (
                 round(win_number / match_number * 100, 2)
                 if match_number
                 else None
             )
-            ratio_color = self.get_ratio_color(win_ratio)
-            ratio_text_color = self.get_ratio_text_color(win_ratio)
+            display_ratio = (
+                ratio_value
+                if ratio_value is not None and win_number > 0
+                else None
+            )
+            ratio_color = self.get_ratio_color(ratio_value)
+            ratio_text_color = self.get_ratio_text_color(ratio_value)
             achievement_color = self.get_achievement_color(match_number, win_number)
             self.result.append(
                 ChampionWinRate(
                     champion=champion,
                     match_number=match_number,
                     win_number=win_number,
-                    win_ratio=win_ratio,
+                    win_ratio=display_ratio,
                     ratio_color=ratio_color,
                     ratio_text_color=ratio_text_color,
                     achievement_color=achievement_color,

--- a/altered/templates/altered/career.html
+++ b/altered/templates/altered/career.html
@@ -34,7 +34,7 @@
         </thead>
         <tbody>
         {% for stat in stats %}
-            <tr {% if stat.win_number == 0 %}style="background-color: #f8d7da;"{% elif stat.win_number >= 25 %}style="background-color: gold;"{% elif stat.win_number >= 10 %}style="background-color: #2493c0;"{% elif stat.win_number >= 5 %}style="background-color: #cd7f32;"{% endif %}>
+            <tr class="{% if stat.win_number|default:0 > 0 %}table-success{% else %}table-danger{% endif %}">
                 <td>{{ stat.champion.name }}</td>
                 <td>{{ stat.champion.faction }}</td>
                 <td>{{ stat.win_number }}</td>

--- a/altered/templates/altered/game_form.html
+++ b/altered/templates/altered/game_form.html
@@ -11,3 +11,57 @@
         </form>
     </div>
 {% endblock %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const factionSelect = document.querySelector('select[name="opponent_faction"]');
+            const championSelect = document.querySelector('select[name="opponent_champion"]');
+
+            if (!factionSelect || !championSelect) {
+                return;
+            }
+
+            let factionMap = {};
+            const factionData = championSelect.dataset.championFactions;
+            if (factionData) {
+                try {
+                    factionMap = JSON.parse(factionData);
+                } catch (error) {
+                    console.error('Unable to parse champion factions data.', error);
+                }
+            }
+
+            const filterChampions = () => {
+                const selectedFaction = factionSelect.value;
+                let resetSelection = false;
+
+                Array.from(championSelect.options).forEach((option) => {
+                    if (!option.value) {
+                        option.hidden = false;
+                        option.disabled = false;
+                        return;
+                    }
+
+                    const optionFaction = factionMap[option.value] || '';
+                    const shouldShow = !selectedFaction || optionFaction === selectedFaction;
+
+                    option.hidden = !shouldShow;
+                    option.disabled = !shouldShow;
+
+                    if (!shouldShow && option.selected) {
+                        resetSelection = true;
+                    }
+                });
+
+                if (resetSelection) {
+                    championSelect.value = '';
+                }
+            };
+
+            factionSelect.addEventListener('change', filterChampions);
+            filterChampions();
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- color career rows green for champions with at least one win and red otherwise
- add an optional opponent faction filter that sorts champions by faction/name and limits the new game form select via client-side filtering
- align win rate display output with expected behaviour while preserving colour gradients

## Testing
- poetry run pytest altered

------
https://chatgpt.com/codex/tasks/task_e_68ced9c0c6448329bf74d80e1778f95c