### PR TITLE
Simplify diaper change tracking

### DIFF
--- a/agathe/forms/diaper_change.py
+++ b/agathe/forms/diaper_change.py
@@ -1,10 +1,8 @@
 from django import forms
 
-from agathe.models import DiaperChange
 
+class DiaperChangeForm(forms.Form):
+    """Empty form used to trigger a diaper change record."""
 
-class DiaperChangeForm(forms.ModelForm):
-    class Meta:
-        model = DiaperChange
-        fields = ["urine", "pooh"]
-        labels = {"pooh": "Caca"}
+    pass
+

--- a/agathe/migrations/0008_diaperchange_simplify.py
+++ b/agathe/migrations/0008_diaperchange_simplify.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def delete_diaper_changes(apps, schema_editor):
+    DiaperChange = apps.get_model("agathe", "DiaperChange")
+    DiaperChange.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agathe", "0007_delete_aspirinintake"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_diaper_changes, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name="diaperchange",
+            name="pooh",
+        ),
+        migrations.RemoveField(
+            model_name="diaperchange",
+            name="urine",
+        ),
+    ]

--- a/agathe/models/diaper_change.py
+++ b/agathe/models/diaper_change.py
@@ -4,11 +4,9 @@ from django.db import models
 
 class DiaperChange(models.Model):
     date = models.DateTimeField()
-    urine = models.BooleanField(default=False)
-    pooh = models.BooleanField(default=False)
 
 
 @admin.register(DiaperChange)
 class DiaperChangeAdmin(admin.ModelAdmin):
-    list_display = ("date", "urine", "pooh")
+    list_display = ("date",)
     ordering = ("-date",)

--- a/agathe/templates/agathe/diaper_change.html
+++ b/agathe/templates/agathe/diaper_change.html
@@ -4,12 +4,7 @@
     <h2 class="mb-4">Changement de couche</h2>
     <form method="post" class="card p-4 shadow-sm mb-5">
         {% csrf_token %}
-        <div class="mb-3">
-            {{ form.urine }} {{ form.urine.label_tag }}
-        </div>
-        <div class="mb-3">
-            {{ form.pooh }} {{ form.pooh.label_tag }}
-        </div>
+        <p class="mb-3">Enregistrer un changement de couche.</p>
         <button type="submit" class="btn btn-primary">Enregistrer</button>
     </form>
     <div class="mt-5">
@@ -20,16 +15,12 @@
                 <thead>
                     <tr>
                         <th>Date</th>
-                        <th>Urine</th>
-                        <th>Caca</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for c in changes %}
                     <tr>
                         <td>{{ c.date|date:"H:i" }}</td>
-                        <td>{{ c.urine|yesno:"Oui,Non" }}</td>
-                        <td>{{ c.pooh|yesno:"Oui,Non" }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/agathe/templates/agathe/home.html
+++ b/agathe/templates/agathe/home.html
@@ -25,14 +25,13 @@
             <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#pitStopModal">Add new</button>
         {% endif %}
     </div>
-    <div class="card p-4 shadow-sm">
+    <div class="card p-4 shadow-sm" style="{% if diaper_overdue %}background-color: lightcoral;{% endif %}">
         <h5>Dernier changement de couche</h5>
         <div class="d-flex justify-content-between align-items-center">
             <div>
                 {% if last_diaper_change %}
                     <ul>
                         <li>{{ last_diaper_change.date|date:"H:i" }}</li>
-                        {% if last_diaper_change.pooh %}<li>Avec crotte</li>{% endif %}
                     </ul>
                 {% else %}
                     <p>Aucun changement de couche enregistré.</p>

--- a/agathe/views/diaper_change.py
+++ b/agathe/views/diaper_change.py
@@ -11,9 +11,7 @@ class DiaperChangeController:
         if request.method == "POST":
             form = DiaperChangeForm(request.POST)
             if form.is_valid():
-                change = form.save(commit=False)
-                change.date = timezone.now()
-                change.save()
+                DiaperChange.objects.create(date=timezone.now())
                 return redirect("agathe:diaper_change")
         else:
             form = DiaperChangeForm()
@@ -23,7 +21,5 @@ class DiaperChangeController:
     @staticmethod
     def quick(request):
         if request.method == "POST":
-            DiaperChange.objects.create(
-                date=timezone.now(), urine=True, pooh=True
-            )
+            DiaperChange.objects.create(date=timezone.now())
         return redirect("agathe:home")

--- a/agathe/views/home.py
+++ b/agathe/views/home.py
@@ -1,7 +1,7 @@
 from django.shortcuts import redirect, render
 from django.utils import timezone
 import calendar
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from agathe.constants.agathe import AgatheConstant
 from agathe.models import PitStop, DiaperChange, VitaminIntake, Bath
@@ -27,6 +27,9 @@ class HomeController:
 
         last_pit_stop = PitStop.objects.order_by("-start_date").first()
         last_diaper_change = DiaperChange.objects.order_by("-date").first()
+        diaper_overdue = False
+        if last_diaper_change:
+            diaper_overdue = timezone.now() - last_diaper_change.date > timedelta(hours=24)
         vitamin_today = VitaminIntake.objects.filter(
             date__date=timezone.now().date()
         ).exists()
@@ -49,6 +52,7 @@ class HomeController:
             {
                 "last_pit_stop": last_pit_stop,
                 "last_diaper_change": last_diaper_change,
+                "diaper_overdue": diaper_overdue,
                 "vitamin_today": vitamin_today,
                 "last_bath": last_bath,
                 "bath_recent": bath_recent,


### PR DESCRIPTION
## Summary
- simplify the diaper change model to keep only the timestamp and remove legacy entries via migration
- adjust diaper change form, views, and template to reflect the simplified data model
- flag overdue diaper changes on the home page so changes older than 24 hours stand out

## Testing
- not run (Django not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7c4054ee08329b08fc3c63108227d