### PR TITLE
feat: color missing career rows by faction

### DIFF
--- a/altered/constants/__init__.py
+++ b/altered/constants/__init__.py
@@ -1,1 +1,2 @@
 from .duration import Duration
+from .faction_colors import FACTION_COLORS

--- a/altered/constants/faction_colors.py
+++ b/altered/constants/faction_colors.py
@@ -1,0 +1,11 @@
+from altered.constants.faction import Faction
+
+
+FACTION_COLORS: dict[str, str] = {
+    Faction.MUNA.value: "#d4edda",   # Green
+    Faction.BRAVOS.value: "#f8d7da",  # Red
+    Faction.AXIOM.value: "#e0c9a6",   # Brown
+    Faction.YZMIR.value: "#e2d9f3",   # Purple
+    Faction.LYRA.value: "#fce4ec",    # Pink
+    Faction.ORDIS.value: "#d1ecf1",   # Light Blue
+}

--- a/altered/templates/altered/career.html
+++ b/altered/templates/altered/career.html
@@ -34,7 +34,7 @@
         </thead>
         <tbody>
         {% for stat in stats %}
-            <tr class="{% if stat.win_number|default:0 > 0 %}table-success{% else %}table-danger{% endif %}">
+            <tr {% if only_missing and stat.row_color %}style="background-color: {{ stat.row_color }}; color: #212529;"{% else %}class="{% if stat.win_number|default:0 > 0 %}table-success{% else %}table-danger{% endif %}"{% endif %}>
                 <td>{{ stat.champion.name }}</td>
                 <td>{{ stat.champion.faction }}</td>
                 <td>{{ stat.win_number }}</td>

--- a/altered/value_objects/career_champion_stats.py
+++ b/altered/value_objects/career_champion_stats.py
@@ -7,3 +7,4 @@ from altered.models import Champion
 class CareerChampionStats:
     champion: Champion
     win_number: int = 0
+    row_color: str | None = None

--- a/altered/views/career.py
+++ b/altered/views/career.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 
+from altered.constants import FACTION_COLORS
 from altered.forms.career_filter import CareerFilterForm
 from altered.services.career_stats import CareerStatsService
 
@@ -14,8 +15,12 @@ def career_view(request):
         name = form.cleaned_data.get('name') or None
         only_missing = form.cleaned_data.get('only_missing')
     service = CareerStatsService(faction=faction, name=name, missing_only=only_missing)
+    if only_missing:
+        for stat in service.result:
+            stat.row_color = FACTION_COLORS.get(stat.champion.faction)
     context = {
         'stats': service.result,
         'form': form,
+        'only_missing': only_missing,
     }
     return render(request, 'altered/career.html', context)


### PR DESCRIPTION
## Summary
- add a reusable constant that maps each faction to its display color
- update the career view to decorate stats with faction colors when filtering missing champions
- render missing-only rows with the faction colors while keeping the previous styling for other modes

## Testing
- pytest altered/tests -q *(fails: missing django dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d06e67748329b947d04250c8e173